### PR TITLE
Structure the readme a bit more naturally (hopefully)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A library that uses [zod schemas](https://github.com/colinhacks/zod) to generate an Open API Swagger documentation.
 
-1. [Purpose and quick example](#purpose)
+1. [Purpose and quick example](#purpose-and-quick-example)
 2. [Usage](#usage)
    1. [Installation](#installation)
    2. [The `openapi` method](#the-openapi-method)
@@ -15,9 +15,9 @@ A library that uses [zod schemas](https://github.com/colinhacks/zod) to generate
 
 We keep a changelog as part of the [GitHub releases](https://github.com/asteasolutions/zod-to-openapi/releases).
 
-## Purpose
+## Purpose and quick example
 
-We at [Astea Solutions](https://asteasolutions.com/) made this library because we use [zod](https://github.com/colinhacks/zod) for validation in our APIs and are tired of the duplication to also support a separate OpenAPI definition that must be kept in sync. Using zod-to-openapi, we generate OpenAPI definitions directly from our zod schemas, this having single source of truth.
+We at [Astea Solutions](https://asteasolutions.com/) made this library because we use [zod](https://github.com/colinhacks/zod) for validation in our APIs and are tired of the duplication to also support a separate OpenAPI definition that must be kept in sync. Using `zod-to-openapi`, we generate OpenAPI definitions directly from our zod schemas, this having single source of truth.
 
 Simply put, it turns this:
 
@@ -292,11 +292,7 @@ components:
   get:
     ...
     parameters:
-      - in: path
-        name: id
-        schema:
-          $ref: '#/components/parameters/UserId'
-        required: true
+      - $ref: '#/components/parameters/UserId'
     responses: ...
 ```
 

--- a/example/openapi-docs.yml
+++ b/example/openapi-docs.yml
@@ -37,12 +37,7 @@ paths:
       description: Get user data by its id
       summary: Get a single user
       parameters:
-        - in: path
-          name: id
-          schema:
-            type: string
-            example: "1212121"
-          required: true
+        - $ref: '#/components/parameters/UserId'
       responses:
         "200":
           description: Object with user data.


### PR DESCRIPTION
Tried to make it as to-the-point as possible, moving some examples around. Idea is that potential users would not read as much text and would want to know what this does and supports as quickly as possible. That's why I've put a full-ish example at the top.

Also tried to move some of the boilerplate after the "meat" (e.g. the "generating doc" part in defining routes)