### PR TITLE
Feature/add support for refined default and optional request body

### DIFF
--- a/spec/simple.spec.ts
+++ b/spec/simple.spec.ts
@@ -265,6 +265,16 @@ describe('Simple', () => {
     );
   });
 
+  it('supports defaults', () => {
+    expectSchema(
+      [z.string().default('test').openapi({ refId: 'StringWithDefault' })],
+      {
+        StringWithDefault: {
+          type: 'string',
+        },
+      }
+    );
+  });
 
   it('supports refined schemas', () => {
     expectSchema(

--- a/src/openapi-generator.ts
+++ b/src/openapi-generator.ts
@@ -18,6 +18,7 @@ import {
 import {
   ZodArray,
   ZodBoolean,
+  ZodDefault,
   ZodEffects,
   ZodEnum,
   ZodIntersection,
@@ -515,6 +516,10 @@ export class OpenAPIGenerator {
       };
     }
 
+    if (zodSchema instanceof ZodDefault) {
+      const innerSchema = zodSchema._def.innerType as ZodSchema<any>;
+      return this.toOpenAPISchema(innerSchema, isNullable, hasOpenAPIType);
+    }
 
     if (
       zodSchema instanceof ZodEffects &&

--- a/src/openapi-generator.ts
+++ b/src/openapi-generator.ts
@@ -18,6 +18,7 @@ import {
 import {
   ZodArray,
   ZodBoolean,
+  ZodEffects,
   ZodEnum,
   ZodIntersection,
   ZodLiteral,
@@ -512,6 +513,15 @@ export class OpenAPIGenerator {
         type: 'boolean',
         nullable: isNullable ? true : undefined,
       };
+    }
+
+
+    if (
+      zodSchema instanceof ZodEffects &&
+      zodSchema._def.effect.type === 'refinement'
+    ) {
+      const innerSchema = zodSchema._def.schema as ZodSchema<any>;
+      return this.toOpenAPISchema(innerSchema, isNullable, hasOpenAPIType);
     }
 
     if (zodSchema instanceof ZodLiteral) {

--- a/src/openapi-generator.ts
+++ b/src/openapi-generator.ts
@@ -389,7 +389,7 @@ export class OpenAPIGenerator {
 
     return {
       description: metadata?.description,
-      required: true,
+      required: !bodySchema.isOptional(),
       content: {
         // TODO: Maybe should be coming from metadata
         'application/json': {


### PR DESCRIPTION
* [#11](https://github.com/asteasolutions/zod-to-openapi/issues/11) added support for optional request bodies
* [#12](https://github.com/asteasolutions/zod-to-openapi/issues/12) added support for `.default()`
* [#13](https://github.com/asteasolutions/zod-to-openapi/issues/13) added support for `.refine()`