### PR TITLE
Handle optional inner types for .default and .refine

### DIFF
--- a/spec/simple.spec.ts
+++ b/spec/simple.spec.ts
@@ -26,7 +26,7 @@ describe('Simple', () => {
     });
   });
 
-  it('does not infer the type if one is provide using .openapi', () => {
+  it('does not infer the type if one is provided using .openapi', () => {
     expectSchema(
       [z.string().openapi({ type: 'number', refId: 'StringAsNumber' })],
       {

--- a/spec/simple.spec.ts
+++ b/spec/simple.spec.ts
@@ -265,31 +265,227 @@ describe('Simple', () => {
     );
   });
 
-  it('supports defaults', () => {
-    expectSchema(
-      [z.string().default('test').openapi({ refId: 'StringWithDefault' })],
-      {
-        StringWithDefault: {
-          type: 'string',
-        },
-      }
-    );
+  describe('defaults', () => {
+    it('supports defaults', () => {
+      expectSchema(
+        [z.string().default('test').openapi({ refId: 'StringWithDefault' })],
+        {
+          StringWithDefault: {
+            type: 'string',
+          },
+        }
+      );
+    });
+
+    it('supports optional defaults', () => {
+      expectSchema(
+        [
+          z
+            .object({
+              test: z.ostring().default('test'),
+            })
+            .openapi({ refId: 'ObjectWithDefault' }),
+        ],
+        {
+          ObjectWithDefault: {
+            type: 'object',
+            properties: {
+              test: {
+                type: 'string',
+              },
+            },
+          },
+        }
+      );
+    });
+
+    it('supports required defaults', () => {
+      expectSchema(
+        [
+          z
+            .object({
+              test: z.string().default('test'),
+            })
+            .openapi({ refId: 'ObjectWithDefault' }),
+        ],
+        {
+          ObjectWithDefault: {
+            type: 'object',
+            properties: {
+              test: {
+                type: 'string',
+              },
+            },
+            required: ['test'],
+          },
+        }
+      );
+    });
+
+    it('supports optional default schemas with refine', () => {
+      expectSchema(
+        [
+          z
+            .object({
+              test: z
+                .onumber()
+                .default(42)
+                .refine((num) => num && num % 2 === 0),
+            })
+            .openapi({ refId: 'Object' }),
+        ],
+        {
+          Object: {
+            type: 'object',
+            properties: {
+              test: {
+                type: 'number',
+              },
+            },
+          },
+        }
+      );
+    });
+
+    it('supports required default schemas with refine', () => {
+      expectSchema(
+        [
+          z
+            .object({
+              test: z
+                .number()
+                .default(42)
+                .refine((num) => num && num % 2 === 0),
+            })
+            .openapi({ refId: 'Object' }),
+        ],
+        {
+          Object: {
+            type: 'object',
+            properties: {
+              test: {
+                type: 'number',
+              },
+            },
+            required: ['test'],
+          },
+        }
+      );
+    });
   });
 
-  it('supports refined schemas', () => {
-    expectSchema(
-      [
-        z
-          .number()
-          .refine((num) => num % 2 === 0)
-          .openapi({ refId: 'RefinedString' }),
-      ],
-      {
-        RefinedString: {
-          type: 'number',
-        },
-      }
-    );
+  describe('refined', () => {
+    it('supports refined schemas', () => {
+      expectSchema(
+        [
+          z
+            .number()
+            .refine((num) => num % 2 === 0)
+            .openapi({ refId: 'RefinedString' }),
+        ],
+        {
+          RefinedString: {
+            type: 'number',
+          },
+        }
+      );
+    });
+
+    it('supports required refined schemas', () => {
+      expectSchema(
+        [
+          z
+            .object({
+              test: z.number().refine((num) => num && num % 2 === 0),
+            })
+            .openapi({ refId: 'ObjectWithRefinedString' }),
+        ],
+        {
+          ObjectWithRefinedString: {
+            type: 'object',
+            properties: {
+              test: {
+                type: 'number',
+              },
+            },
+            required: ['test'],
+          },
+        }
+      );
+    });
+
+    it('supports optional refined schemas', () => {
+      expectSchema(
+        [
+          z
+            .object({
+              test: z.onumber().refine((num) => num && num % 2 === 0),
+            })
+            .openapi({ refId: 'ObjectWithRefinedString' }),
+        ],
+        {
+          ObjectWithRefinedString: {
+            type: 'object',
+            properties: {
+              test: {
+                type: 'number',
+              },
+            },
+          },
+        }
+      );
+    });
+
+    it('supports optional refined schemas with default', () => {
+      expectSchema(
+        [
+          z
+            .object({
+              test: z
+                .onumber()
+                .refine((num) => num && num % 2 === 0)
+                .default(42),
+            })
+            .openapi({ refId: 'Object' }),
+        ],
+        {
+          Object: {
+            type: 'object',
+            properties: {
+              test: {
+                type: 'number',
+              },
+            },
+          },
+        }
+      );
+    });
+
+    it('supports required refined schemas with default', () => {
+      expectSchema(
+        [
+          z
+            .object({
+              test: z
+                .number()
+                .refine((num) => num && num % 2 === 0)
+                .default(42),
+            })
+            .openapi({ refId: 'Object' }),
+        ],
+        {
+          Object: {
+            type: 'object',
+            properties: {
+              test: {
+                type: 'number',
+              },
+            },
+            required: ['test'],
+          },
+        }
+      );
+    });
   });
 
   it('does not support transformed schemas', () => {

--- a/spec/simple.spec.ts
+++ b/spec/simple.spec.ts
@@ -26,6 +26,15 @@ describe('Simple', () => {
     });
   });
 
+  it('does not infer the type if one is provide using .openapi', () => {
+    expectSchema(
+      [z.string().openapi({ type: 'number', refId: 'StringAsNumber' })],
+      {
+        StringAsNumber: { type: 'number' },
+      }
+    );
+  });
+
   it('generates schemas with metadata', () => {
     expectSchema(
       [z.string().openapi({ refId: 'SimpleString', description: 'test' })],

--- a/spec/simple.spec.ts
+++ b/spec/simple.spec.ts
@@ -486,6 +486,35 @@ describe('Simple', () => {
         }
       );
     });
+
+    it('supports refined transforms when type is provided', () => {
+      expectSchema(
+        [
+          z
+            .object({
+              test: z
+                .string()
+                .transform((value) => value.trim())
+                .refine((val) => val.length >= 1, 'Value not set.')
+                .openapi({
+                  type: 'string',
+                }),
+            })
+            .openapi({ refId: 'Object' }),
+        ],
+        {
+          Object: {
+            type: 'object',
+            properties: {
+              test: {
+                type: 'string',
+              },
+            },
+            required: ['test'],
+          },
+        }
+      );
+    });
   });
 
   it('does not support transformed schemas', () => {

--- a/src/openapi-generator.ts
+++ b/src/openapi-generator.ts
@@ -335,11 +335,11 @@ export class OpenAPIGenerator {
       };
     }
 
-    const result = this.toOpenAPISchema(
-      innerSchema,
-      zodSchema.isNullable(),
-      !!metadata?.type
-    );
+    const result = metadata?.type
+      ? {
+          type: metadata?.type,
+        }
+      : this.toOpenAPISchema(innerSchema, zodSchema.isNullable());
 
     return metadata
       ? this.applySchemaMetadata(result, metadata)
@@ -487,8 +487,7 @@ export class OpenAPIGenerator {
 
   private toOpenAPISchema(
     zodSchema: ZodSchema<any>,
-    isNullable: boolean,
-    hasOpenAPIType: boolean
+    isNullable: boolean
   ): SchemaObject {
     if (zodSchema instanceof ZodNull) {
       return { type: 'null' };
@@ -600,7 +599,7 @@ export class OpenAPIGenerator {
       };
     }
 
-    if (zodSchema instanceof ZodUnknown || hasOpenAPIType) {
+    if (zodSchema instanceof ZodUnknown) {
       return {};
     }
 


### PR DESCRIPTION
Handle optional inner types for .default and .refine
Made sure that an externally provided type takes precedence