### PR TITLE
Make the zod dependency a major version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,10 +17,10 @@
         "ts-jest": "^27.1.4",
         "typescript": "^4.6.3",
         "yaml": "^2.0.0",
-        "zod": "~3.14.4"
+        "zod": "^3.0.0"
       },
       "peerDependencies": {
-        "zod": "~3.14.4"
+        "zod": "^3.0.0"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -4124,9 +4124,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "3.14.4",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.14.4.tgz",
-      "integrity": "sha512-U9BFLb2GO34Sfo9IUYp0w3wJLlmcyGoMd75qU9yf+DrdGA4kEx6e+l9KOkAlyUO0PSQzZCa3TR4qVlcmwqSDuw==",
+      "version": "3.17.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.17.3.tgz",
+      "integrity": "sha512-4oKP5zvG6GGbMlqBkI5FESOAweldEhSOZ6LI6cG+JzUT7ofj1ZOC0PJudpQOpT1iqOFpYYtX5Pw0+o403y4bcg==",
       "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
@@ -7267,9 +7267,9 @@
       "dev": true
     },
     "zod": {
-      "version": "3.14.4",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.14.4.tgz",
-      "integrity": "sha512-U9BFLb2GO34Sfo9IUYp0w3wJLlmcyGoMd75qU9yf+DrdGA4kEx6e+l9KOkAlyUO0PSQzZCa3TR4qVlcmwqSDuw==",
+      "version": "3.17.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.17.3.tgz",
+      "integrity": "sha512-4oKP5zvG6GGbMlqBkI5FESOAweldEhSOZ6LI6cG+JzUT7ofj1ZOC0PJudpQOpT1iqOFpYYtX5Pw0+o403y4bcg==",
       "dev": true
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,10 +17,10 @@
         "ts-jest": "^27.1.4",
         "typescript": "^4.6.3",
         "yaml": "^2.0.0",
-        "zod": "^3.0.0"
+        "zod": "^3.14.0"
       },
       "peerDependencies": {
-        "zod": "^3.0.0"
+        "zod": "^3.14.0"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "openapi3-ts": "^2.0.2"
   },
   "peerDependencies": {
-    "zod": "^3.0.0"
+    "zod": "^3.14.0"
   },
   "devDependencies": {
     "@types/jest": "^27.4.1",
@@ -38,7 +38,7 @@
     "ts-jest": "^27.1.4",
     "typescript": "^4.6.3",
     "yaml": "^2.0.0",
-    "zod": "^3.0.0"
+    "zod": "^3.14.0"
   },
   "author": "Astea Solutions <info@asteasolutions.com>",
   "license": "MIT"

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "openapi3-ts": "^2.0.2"
   },
   "peerDependencies": {
-    "zod": "~3.14.4"
+    "zod": "^3.0.0"
   },
   "devDependencies": {
     "@types/jest": "^27.4.1",
@@ -38,7 +38,7 @@
     "ts-jest": "^27.1.4",
     "typescript": "^4.6.3",
     "yaml": "^2.0.0",
-    "zod": "~3.14.4"
+    "zod": "^3.0.0"
   },
   "author": "Astea Solutions <info@asteasolutions.com>",
   "license": "MIT"


### PR DESCRIPTION
The zod dependency (dev and peer) is now  `^3.0.0` (“Compatible with version” ).
Fixes #23    