### PR TITLE
feat: add ability to define securitySchemes under components

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "openapi3-ts": "^2.0.2"
       },
       "devDependencies": {
-        "@types/jest": "^27.4.1",
+        "@types/jest": "^27.5.2",
         "jest": "^27.5.1",
         "ts-jest": "^27.1.4",
         "typescript": "^4.6.3",
@@ -965,9 +965,9 @@
       }
     },
     "node_modules/@types/jest": {
-      "version": "27.4.1",
-      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-27.4.1.tgz",
-      "integrity": "sha512-23iPJADSmicDVrWk+HT58LMJtzLAnB2AgIzplQuq/bSrGaxCrlvRFjGbXmamnnk/mAmCdLStiGqggu28ocUyiw==",
+      "version": "27.5.2",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-27.5.2.tgz",
+      "integrity": "sha512-mpT8LJJ4CMeeahobofYWIjFo0xonRS/HfxnVEPMPFSQdGUt1uHCnoPT7Zhb+sjDU2wz0oKV0OLUR0WzrHNgfeA==",
       "dev": true,
       "dependencies": {
         "jest-matcher-utils": "^27.0.0",
@@ -4880,9 +4880,9 @@
       }
     },
     "@types/jest": {
-      "version": "27.4.1",
-      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-27.4.1.tgz",
-      "integrity": "sha512-23iPJADSmicDVrWk+HT58LMJtzLAnB2AgIzplQuq/bSrGaxCrlvRFjGbXmamnnk/mAmCdLStiGqggu28ocUyiw==",
+      "version": "27.5.2",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-27.5.2.tgz",
+      "integrity": "sha512-mpT8LJJ4CMeeahobofYWIjFo0xonRS/HfxnVEPMPFSQdGUt1uHCnoPT7Zhb+sjDU2wz0oKV0OLUR0WzrHNgfeA==",
       "dev": true,
       "requires": {
         "jest-matcher-utils": "^27.0.0",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.2.3",
   "description": "Builds OpenAPI schemas from Zod schemas",
   "main": "dist/index.js",
+  "types": "dist/index.d.ts",
   "files": [
     "dist",
     "package.json",
@@ -23,6 +24,7 @@
   "homepage": "https://github.com/asteasolutions/zod-to-openapi",
   "scripts": {
     "build": "tsc -p tsconfig.build.json",
+    "dev": "npm run build -- --watch",
     "test": "jest",
     "prepublishOnly": "npm run build"
   },
@@ -33,7 +35,7 @@
     "zod": "^3.14.0"
   },
   "devDependencies": {
-    "@types/jest": "^27.4.1",
+    "@types/jest": "^27.5.2",
     "jest": "^27.5.1",
     "ts-jest": "^27.1.4",
     "typescript": "^4.6.3",

--- a/spec/securitySchemas.spec.ts
+++ b/spec/securitySchemas.spec.ts
@@ -1,0 +1,70 @@
+import { OpenAPIGenerator } from '../src/openapi-generator';
+import { OpenAPIRegistry } from '../src/openapi-registry';
+import { SecuritySchemeObject } from 'openapi3-ts';
+import { z } from 'zod';
+import {extendZodWithOpenApi} from "../src";
+
+const testDocConfig = {
+  openapi: '3.0.0',
+  info: {
+    version: '1.0.0',
+    title: 'Swagger Petstore',
+    description: 'A sample API',
+    termsOfService: 'http://swagger.io/terms/',
+    license: {
+      name: 'Apache 2.0',
+      url: 'https://www.apache.org/licenses/LICENSE-2.0.html',
+    },
+  },
+  servers: [{ url: 'v1' }],
+};
+
+extendZodWithOpenApi(z);
+
+describe('securitySchemas', () => {
+  const registry = new OpenAPIRegistry();
+
+  const bearerAuth = registry.registerSecurityScheme('bearerAuth', {
+    type: 'http',
+    scheme: 'bearer',
+    bearerFormat: 'JWT',
+  })
+
+  const Unit = registry.register('UnitDto', z.object({
+    id: z.string().uuid(),
+    name: z.string(),
+  })).openapi({description: 'unit'})
+
+  registry.registerPath({
+    path: '/units',
+    method: 'get',
+    security: [
+      bearerAuth.security(),
+    ],
+    responses: {
+      200: {
+        mediaType: 'application/json',
+        schema: Unit.array().openapi({description: 'Array of all units'})
+      }
+    }
+  })
+
+  const builder = new OpenAPIGenerator(registry.definitions)
+  const doc = builder.generateDocument(testDocConfig);
+
+  it('should have security in /units', () => {
+    expect(doc.paths!['/units'].get.security).toStrictEqual([
+      {
+        bearerAuth: []
+      }
+    ]);
+  })
+
+  it('should have securitySchemes', () => {
+    expect(doc.components!.securitySchemes).toStrictEqual({bearerAuth: {
+      bearerFormat: "JWT",
+      scheme: "bearer",
+      type: "http",
+    }});
+  })
+})

--- a/src/openapi-registry.ts
+++ b/src/openapi-registry.ts
@@ -1,6 +1,6 @@
 import {OpenAPIObject, OperationObject} from 'openapi3-ts';
 import type { ZodVoid, ZodObject, ZodSchema, ZodType } from 'zod';
-import {SecuritySchemeObject} from "openapi3-ts/src/model/OpenApi";
+import { SecuritySchemeObject } from 'openapi3-ts';
 
 type Method = 'get' | 'post' | 'put' | 'delete' | 'patch';
 

--- a/src/openapi-registry.ts
+++ b/src/openapi-registry.ts
@@ -1,5 +1,6 @@
-import { OperationObject } from 'openapi3-ts';
+import {OpenAPIObject, OperationObject} from 'openapi3-ts';
 import type { ZodVoid, ZodObject, ZodSchema, ZodType } from 'zod';
+import {SecuritySchemeObject} from "openapi3-ts/src/model/OpenApi";
 
 type Method = 'get' | 'post' | 'put' | 'delete' | 'patch';
 
@@ -23,6 +24,7 @@ export interface RouteConfig extends OperationObject {
 
 export type OpenAPIDefinitions =
   | { type: 'schema'; schema: ZodSchema<any> }
+  | { type: 'securitySchema'; name: string, schema: SecuritySchemeObject }
   | { type: 'parameter'; schema: ZodSchema<any> }
   | { type: 'route'; route: RouteConfig };
 
@@ -51,6 +53,20 @@ export class OpenAPIRegistry {
     this._definitions.push({ type: 'schema', schema: schemaWithMetadata });
 
     return schemaWithMetadata;
+  }
+
+  registerSecurityScheme(name: string, schema: SecuritySchemeObject) {
+    this._definitions.push({
+      type: 'securitySchema',
+      name,
+      schema,
+    })
+
+    return {
+      name,
+      schema: {...schema},
+      security: (val: string[] = []) => ({[name]: val}),
+    }
   }
 
   /**


### PR DESCRIPTION
Hi, there is a small change that I missed when using this package: having to define my securitySchemes (as of v3 of open api)

I hope you too find it useful and it'll get merged shortly.

Any feedback would be appreciated!

Thanks