### PR TITLE
Add support for integers

### DIFF
--- a/spec/simple.spec.ts
+++ b/spec/simple.spec.ts
@@ -2,9 +2,21 @@ import { z } from 'zod';
 import { createSchemas, expectSchema } from './lib/helpers';
 
 describe('Simple', () => {
-  it('generates OpenAPI schema for simple types', () => {
+  it('generates OpenAPI schema for a simple string type', () => {
     expectSchema([z.string().openapi({ refId: 'SimpleString' })], {
       SimpleString: { type: 'string' },
+    });
+  });
+
+  it('generates OpenAPI schema for a simple number type', () => {
+    expectSchema([z.number().openapi({ refId: 'SimpleNumber' })], {
+      SimpleNumber: { type: 'number' },
+    });
+  });
+
+  it('generates OpenAPI schema for a simple integer type', () => {
+    expectSchema([z.number().int().openapi({ refId: 'SimpleInteger' })], {
+      SimpleInteger: { type: 'integer' },
     });
   });
 

--- a/src/openapi-generator.ts
+++ b/src/openapi-generator.ts
@@ -520,7 +520,7 @@ export class OpenAPIGenerator {
 
     if (isZodType(zodSchema, 'ZodNumber')) {
       return {
-        type: 'number',
+        type: zodSchema.isInt ? 'integer' : 'number',
         minimum: zodSchema.minValue ?? undefined,
         maximum: zodSchema.maxValue ?? undefined,
         nullable: isNullable ? true : undefined,


### PR DESCRIPTION
Hey legends, love this library so far. Just a small 🤏 PR to map numbers to integers when `.int()` is used.