### PR TITLE
Allow for root level specification extensions

### DIFF
--- a/src/openapi-generator.ts
+++ b/src/openapi-generator.ts
@@ -60,6 +60,9 @@ interface OpenAPIObjectConfig {
   security?: SecurityRequirementObject[];
   tags?: TagObject[];
   externalDocs?: ExternalDocumentationObject;
+
+  // Allow for specification extension keys
+  [key: string]: unknown;
 }
 
 interface ParameterData {


### PR DESCRIPTION
Sorry, another quick one 😅 

Allows for some additional keys to be specified while still maintaining type support. Most specifically I need `x-tagGroups` from [redocly](https://redocly.com/docs/api-reference-docs/spec-extensions/) but I imagine other vendors also have some additional keys they use.

<img width="551" alt="image" src="https://user-images.githubusercontent.com/18017094/194320219-5cf6a73d-6b00-47d3-a967-2e1ac0d7d1c3.png">
