### PR TITLE
Treat omit/pick as new objects

### DIFF
--- a/spec/polymorphism.spec.ts
+++ b/spec/polymorphism.spec.ts
@@ -135,7 +135,7 @@ describe('Polymorphism', () => {
     });
   });
 
-  it('correctly creates references to existing schema objects using refId', () => {
+  it('treats objects created by .omit as a new object', () => {
     const BaseSchema = z
       .object({
         name: z.string(),
@@ -145,55 +145,10 @@ describe('Polymorphism', () => {
         refId: 'Base',
       });
 
-    const OtherSchema = z
-      .object({
-        base: BaseSchema,
-      })
-      .openapi({
-        refId: 'Other',
-      });
-
-    expectSchema([BaseSchema, OtherSchema], {
-      Base: {
-        properties: {
-          name: {
-            type: 'string',
-          },
-          type: {
-            enum: ['dog', 'cat'],
-            type: 'string',
-          },
-        },
-        required: ['name'],
-        type: 'object',
-      },
-      Other: {
-        properties: {
-          base: {
-            $ref: '#/components/schemas/Base',
-          },
-        },
-        required: ['base'],
-        type: 'object',
-      },
-    });
-  });
-
-  it('treats objects created by .omit and .pick as new objects', () => {
-    const BaseSchema = z
-      .object({
-        name: z.string(),
-        type: z.enum(['dog', 'cat']).optional(),
-      })
-      .openapi({
-        refId: 'Base',
-      });
-
-    const PickedSchema = BaseSchema.pick({ name: true });
     const OmittedSchema = BaseSchema.omit({ type: true });
 
     const OtherSchema = z
-      .object({ omit: OmittedSchema, pick: PickedSchema })
+      .object({ omit: OmittedSchema })
       .openapi({ refId: 'Other' });
 
     expectSchema([BaseSchema, OtherSchema], {
@@ -221,6 +176,45 @@ describe('Polymorphism', () => {
             required: ['name'],
             type: 'object',
           },
+        },
+        required: ['omit'],
+        type: 'object',
+      },
+    });
+  });
+
+  it('treats objects created by .pick as a new object', () => {
+    const BaseSchema = z
+      .object({
+        name: z.string(),
+        type: z.enum(['dog', 'cat']).optional(),
+      })
+      .openapi({
+        refId: 'Base',
+      });
+
+    const PickedSchema = BaseSchema.pick({ name: true });
+
+    const OtherSchema = z
+      .object({ pick: PickedSchema })
+      .openapi({ refId: 'Other' });
+
+    expectSchema([BaseSchema, OtherSchema], {
+      Base: {
+        properties: {
+          name: {
+            type: 'string',
+          },
+          type: {
+            enum: ['dog', 'cat'],
+            type: 'string',
+          },
+        },
+        required: ['name'],
+        type: 'object',
+      },
+      Other: {
+        properties: {
           pick: {
             properties: {
               name: {
@@ -231,7 +225,7 @@ describe('Polymorphism', () => {
             type: 'object',
           },
         },
-        required: ['omit', 'pick'],
+        required: ['pick'],
         type: 'object',
       },
     });

--- a/src/zod-extensions.ts
+++ b/src/zod-extensions.ts
@@ -89,7 +89,7 @@ export function extendZodWithOpenApi(zod: typeof z) {
   const zodPick = zod.ZodObject.prototype.pick as any;
   zod.ZodObject.prototype.pick = function (this: any, ...args: any[]) {
     const result = zodPick.apply(this, args);
-    result._def.openapi = {};
+    result._def.openapi = undefined;
 
     return result;
   };
@@ -97,7 +97,7 @@ export function extendZodWithOpenApi(zod: typeof z) {
   const zodOmit = zod.ZodObject.prototype.omit as any;
   zod.ZodObject.prototype.omit = function (this: any, ...args: any[]) {
     const result = zodOmit.apply(this, args);
-    result._def.openapi = {};
+    result._def.openapi = undefined;
 
     return result;
   };

--- a/src/zod-extensions.ts
+++ b/src/zod-extensions.ts
@@ -85,4 +85,20 @@ export function extendZodWithOpenApi(zod: typeof z) {
 
     return result;
   };
+
+  const zodPick = zod.ZodObject.prototype.pick as any;
+  zod.ZodObject.prototype.pick = function (this: any, ...args: any[]) {
+    const result = zodPick.apply(this, args);
+    result._def.openapi = {};
+
+    return result;
+  };
+
+  const zodOmit = zod.ZodObject.prototype.omit as any;
+  zod.ZodObject.prototype.omit = function (this: any, ...args: any[]) {
+    const result = zodOmit.apply(this, args);
+    result._def.openapi = {};
+
+    return result;
+  };
 }


### PR DESCRIPTION
When I gave something a `refId` and I used `omit` and `pick` on that object. The resulting schema was still trying to use the existing `refId` which is incorrect. This treats new objects created with `.omit` and `.pick` as new objects essentially by clearing the `_def.openapi` from the object. Not sure if there's a better way to do this?