### PR TITLE
Support zod preprocessed schemas

### DIFF
--- a/spec/simple.spec.ts
+++ b/spec/simple.spec.ts
@@ -715,7 +715,7 @@ describe('Simple', () => {
         ],
         {
           PreprocessedNumber: {
-            type: 'number'
+            type: 'number',
           },
         }
       );

--- a/spec/simple.spec.ts
+++ b/spec/simple.spec.ts
@@ -669,6 +669,59 @@ describe('Simple', () => {
     });
   });
 
+  describe('preprocessed', () => {
+    it('supports preprocessed string -> boolean schema', () => {
+      expectSchema(
+        [
+          z
+            .preprocess(arg => {
+              if (typeof arg === 'boolean') {
+                return arg;
+              }
+
+              if (typeof arg === 'string') {
+                if (arg === 'true') return true;
+                if (arg === 'false') return false;
+              }
+
+              return undefined;
+            }, z.boolean())
+            .openapi({ refId: 'PreprocessedBoolean' }),
+        ],
+        {
+          PreprocessedBoolean: {
+            type: 'boolean',
+          },
+        }
+      );
+    });
+
+    it('supports preprocessed string -> number schema', () => {
+      expectSchema(
+        [
+          z
+            .preprocess(arg => {
+              if (typeof arg === 'number') {
+                return arg;
+              }
+
+              if (typeof arg === 'string') {
+                return parseInt(arg, 10);
+              }
+
+              return undefined;
+            }, z.number())
+            .openapi({ refId: 'PreprocessedNumber' }),
+        ],
+        {
+          PreprocessedNumber: {
+            type: 'number'
+          },
+        }
+      );
+    });
+  });
+
   it('does not support transformed schemas', () => {
     expect(() =>
       createSchemas([

--- a/src/openapi-generator.ts
+++ b/src/openapi-generator.ts
@@ -584,7 +584,7 @@ export class OpenAPIGenerator {
 
     if (
       isZodType(zodSchema, 'ZodEffects') &&
-      zodSchema._def.effect.type === 'refinement'
+      (zodSchema._def.effect.type === 'refinement' || zodSchema._def.effect.type === 'preprocess')
     ) {
       const innerSchema = zodSchema._def.schema as ZodSchema<any>;
       return this.generateInnerSchema(innerSchema);

--- a/src/openapi-generator.ts
+++ b/src/openapi-generator.ts
@@ -584,7 +584,8 @@ export class OpenAPIGenerator {
 
     if (
       isZodType(zodSchema, 'ZodEffects') &&
-      (zodSchema._def.effect.type === 'refinement' || zodSchema._def.effect.type === 'preprocess')
+      (zodSchema._def.effect.type === 'refinement' ||
+        zodSchema._def.effect.type === 'preprocess')
     ) {
       const innerSchema = zodSchema._def.schema as ZodSchema<any>;
       return this.generateInnerSchema(innerSchema);


### PR DESCRIPTION
Since an OpenAPI request's underlying `params` and `query` values can only be `string`, it's very common having to resort to `z.preprocess(...)` to convert them to the desired type.

This PR adds support for `z.preprocess(...)`, similarly to the recent addition of support for `refine(...)`.