### PR TITLE
Add webhooks support

### DIFF
--- a/spec/routes.spec.ts
+++ b/spec/routes.spec.ts
@@ -31,474 +31,473 @@ const testDocConfig = {
   servers: [{ url: 'v1' }],
 };
 
-describe.each`
-  type          | registerFunction     | rootDocPath
-  ${'Routes'}   | ${'registerPath'}    | ${'paths'}
-  ${'Webhooks'} | ${'registerWebhook'} | ${'webhooks'}
-`(
-  '$type',
-  ({
-    registerFunction,
-    rootDocPath,
-  }: {
-    registerFunction: 'registerPath' | 'registerWebhook';
-    rootDocPath: 'paths' | 'webhooks';
-  }) => {
-    describe('response definitions', () => {
-      it('can set description', () => {
-        const registry = new OpenAPIRegistry();
+const routeTests = ({
+  registerFunction,
+  rootDocPath,
+}: {
+  registerFunction: 'registerPath' | 'registerWebhook';
+  rootDocPath: 'paths' | 'webhooks';
+}) => {
+  describe('response definitions', () => {
+    it('can set description', () => {
+      const registry = new OpenAPIRegistry();
 
-        registry[registerFunction]({
-          method: 'get',
-          path: '/',
-          responses: {
-            200: {
-              description: 'Simple response',
-              content: {
-                'application/json': {
-                  schema: z.string(),
-                },
-              },
-            },
-
-            404: {
-              description: 'Missing object',
-              content: {
-                'application/json': {
-                  schema: z.string(),
-                },
+      registry[registerFunction]({
+        method: 'get',
+        path: '/',
+        responses: {
+          200: {
+            description: 'Simple response',
+            content: {
+              'application/json': {
+                schema: z.string(),
               },
             },
           },
-        });
 
-        const document = new OpenAPIGenerator(
-          registry.definitions
-        ).generateDocument(testDocConfig);
-        const responses = document[rootDocPath]['/'].get.responses;
-
-        expect(responses['200'].description).toEqual('Simple response');
-        expect(responses['404'].description).toEqual('Missing object');
+          404: {
+            description: 'Missing object',
+            content: {
+              'application/json': {
+                schema: z.string(),
+              },
+            },
+          },
+        },
       });
 
-      it('can specify response with plain OpenApi format', () => {
-        const registry = new OpenAPIRegistry();
+      const document = new OpenAPIGenerator(
+        registry.definitions
+      ).generateDocument(testDocConfig);
+      const responses = document[rootDocPath]['/'].get.responses;
 
-        registry[registerFunction]({
-          method: 'get',
-          path: '/',
-          responses: {
-            200: {
-              description: 'Simple response',
-              content: {
-                'application/json': {
-                  schema: {
-                    type: 'string',
-                    example: 'test',
-                  },
-                },
-              },
-            },
+      expect(responses['200'].description).toEqual('Simple response');
+      expect(responses['404'].description).toEqual('Missing object');
+    });
 
-            404: {
-              description: 'Missing object',
-              content: {
-                'application/json': {
-                  schema: {
-                    $ref: '#/components/schemas/SomeRef',
-                  },
+    it('can specify response with plain OpenApi format', () => {
+      const registry = new OpenAPIRegistry();
+
+      registry[registerFunction]({
+        method: 'get',
+        path: '/',
+        responses: {
+          200: {
+            description: 'Simple response',
+            content: {
+              'application/json': {
+                schema: {
+                  type: 'string',
+                  example: 'test',
                 },
               },
             },
           },
-        });
 
-        const document = new OpenAPIGenerator(
-          registry.definitions
-        ).generateDocument(testDocConfig);
-        const responses = document[rootDocPath]['/'].get.responses;
-
-        expect(responses['200'].content['application/json'].schema).toEqual({
-          type: 'string',
-          example: 'test',
-        });
-        expect(responses['404'].content['application/json'].schema).toEqual({
-          $ref: '#/components/schemas/SomeRef',
-        });
+          404: {
+            description: 'Missing object',
+            content: {
+              'application/json': {
+                schema: {
+                  $ref: '#/components/schemas/SomeRef',
+                },
+              },
+            },
+          },
+        },
       });
 
-      it('can set multiple response formats', () => {
-        const registry = new OpenAPIRegistry();
+      const document = new OpenAPIGenerator(
+        registry.definitions
+      ).generateDocument(testDocConfig);
+      const responses = document[rootDocPath]['/'].get.responses;
 
-        const UserSchema = registry.register(
-          'User',
-          z.object({ name: z.string() })
-        );
-
-        registry[registerFunction]({
-          method: 'get',
-          path: '/',
-          responses: {
-            200: {
-              description: 'Simple response',
-              content: {
-                'application/json': {
-                  schema: UserSchema,
-                },
-                'application/xml': {
-                  schema: UserSchema,
-                },
-              },
-            },
-          },
-        });
-
-        const document = new OpenAPIGenerator(
-          registry.definitions
-        ).generateDocument(testDocConfig);
-        const responses = document[rootDocPath]['/'].get.responses;
-
-        expect(responses['200'].description).toEqual('Simple response');
-        expect(responses['200'].content['application/json'].schema).toEqual({
-          $ref: '#/components/schemas/User',
-        });
-        expect(responses['200'].content['application/xml'].schema).toEqual({
-          $ref: '#/components/schemas/User',
-        });
+      expect(responses['200'].content['application/json'].schema).toEqual({
+        type: 'string',
+        example: 'test',
       });
-
-      it('can generate responses without content', () => {
-        const registry = new OpenAPIRegistry();
-
-        registry[registerFunction]({
-          method: 'get',
-          path: '/',
-          responses: {
-            204: {
-              description: 'Success',
-            },
-          },
-        });
-
-        const document = new OpenAPIGenerator(
-          registry.definitions
-        ).generateDocument(testDocConfig);
-        const responses = document[rootDocPath]['/'].get.responses;
-
-        expect(responses['204']).toEqual({ description: 'Success' });
+      expect(responses['404'].content['application/json'].schema).toEqual({
+        $ref: '#/components/schemas/SomeRef',
       });
     });
 
-    describe('parameters', () => {
-      it('generates a query parameter for route', () => {
-        const routeParameters = generateParamsForRoute({
-          request: { query: z.object({ test: z.string() }) },
-        });
+    it('can set multiple response formats', () => {
+      const registry = new OpenAPIRegistry();
 
-        expect(routeParameters).toEqual([
-          {
-            in: 'query',
-            name: 'test',
-            required: true,
-            schema: {
-              type: 'string',
+      const UserSchema = registry.register(
+        'User',
+        z.object({ name: z.string() })
+      );
+
+      registry[registerFunction]({
+        method: 'get',
+        path: '/',
+        responses: {
+          200: {
+            description: 'Simple response',
+            content: {
+              'application/json': {
+                schema: UserSchema,
+              },
+              'application/xml': {
+                schema: UserSchema,
+              },
             },
           },
-        ]);
+        },
       });
 
-      it('generates a path parameter for route', () => {
-        const routeParameters = generateParamsForRoute({
-          request: { params: z.object({ test: z.string() }) },
-        });
+      const document = new OpenAPIGenerator(
+        registry.definitions
+      ).generateDocument(testDocConfig);
+      const responses = document[rootDocPath]['/'].get.responses;
 
-        expect(routeParameters).toEqual([
-          {
-            in: 'path',
-            name: 'test',
-            required: true,
-            schema: {
-              type: 'string',
+      expect(responses['200'].description).toEqual('Simple response');
+      expect(responses['200'].content['application/json'].schema).toEqual({
+        $ref: '#/components/schemas/User',
+      });
+      expect(responses['200'].content['application/xml'].schema).toEqual({
+        $ref: '#/components/schemas/User',
+      });
+    });
+
+    it('can generate responses without content', () => {
+      const registry = new OpenAPIRegistry();
+
+      registry[registerFunction]({
+        method: 'get',
+        path: '/',
+        responses: {
+          204: {
+            description: 'Success',
+          },
+        },
+      });
+
+      const document = new OpenAPIGenerator(
+        registry.definitions
+      ).generateDocument(testDocConfig);
+      const responses = document[rootDocPath]['/'].get.responses;
+
+      expect(responses['204']).toEqual({ description: 'Success' });
+    });
+  });
+
+  describe('parameters', () => {
+    it('generates a query parameter for route', () => {
+      const routeParameters = generateParamsForRoute({
+        request: { query: z.object({ test: z.string() }) },
+      });
+
+      expect(routeParameters).toEqual([
+        {
+          in: 'query',
+          name: 'test',
+          required: true,
+          schema: {
+            type: 'string',
+          },
+        },
+      ]);
+    });
+
+    it('generates a path parameter for route', () => {
+      const routeParameters = generateParamsForRoute({
+        request: { params: z.object({ test: z.string() }) },
+      });
+
+      expect(routeParameters).toEqual([
+        {
+          in: 'path',
+          name: 'test',
+          required: true,
+          schema: {
+            type: 'string',
+          },
+        },
+      ]);
+    });
+
+    it('generates a header parameter for route', () => {
+      const routeParameters = generateParamsForRoute({
+        request: {
+          headers: [z.string().openapi({ param: { name: 'test' } })],
+        },
+      });
+
+      expect(routeParameters).toEqual([
+        {
+          in: 'header',
+          name: 'test',
+          required: true,
+          schema: {
+            type: 'string',
+          },
+        },
+      ]);
+    });
+
+    it('generates a reference header parameter for route', () => {
+      const TestHeader = z.string().openapi({
+        refId: 'TestHeader',
+        param: { name: 'test', in: 'header' },
+      });
+
+      const routeParameters = generateParamsForRoute(
+        {
+          request: { headers: [TestHeader] },
+        },
+        [TestHeader]
+      );
+
+      expect(routeParameters).toEqual([
+        {
+          $ref: '#/components/parameters/TestHeader',
+        },
+      ]);
+    });
+
+    it('generates a reference query parameter for route', () => {
+      const TestQuery = z.string().openapi({
+        refId: 'TestQuery',
+        param: { name: 'test', in: 'query' },
+      });
+
+      const routeParameters = generateParamsForRoute(
+        {
+          request: { query: z.object({ test: TestQuery }) },
+        },
+        [TestQuery]
+      );
+
+      expect(routeParameters).toEqual([
+        {
+          $ref: '#/components/parameters/TestQuery',
+        },
+      ]);
+    });
+
+    describe('errors', () => {
+      it('throws an error in case of names mismatch', () => {
+        expect(() =>
+          generateParamsForRoute({
+            request: {
+              query: z.object({
+                test: z.string().openapi({ param: { name: 'another' } }),
+              }),
             },
-          },
-        ]);
+          })
+        ).toThrowError(/^Conflicting name/);
       });
 
-      it('generates a header parameter for route', () => {
-        const routeParameters = generateParamsForRoute({
-          request: {
-            headers: [z.string().openapi({ param: { name: 'test' } })],
-          },
-        });
-
-        expect(routeParameters).toEqual([
-          {
-            in: 'header',
-            name: 'test',
-            required: true,
-            schema: {
-              type: 'string',
+      it('throws an error in case of location mismatch', () => {
+        expect(() =>
+          generateParamsForRoute({
+            request: {
+              query: z.object({
+                test: z.string().openapi({ param: { in: 'header' } }),
+              }),
             },
-          },
-        ]);
+          })
+        ).toThrowError(/^Conflicting location/);
       });
 
-      it('generates a reference header parameter for route', () => {
+      it('throws an error in case of location mismatch with reference', () => {
         const TestHeader = z.string().openapi({
           refId: 'TestHeader',
           param: { name: 'test', in: 'header' },
         });
 
-        const routeParameters = generateParamsForRoute(
-          {
-            request: { headers: [TestHeader] },
-          },
-          [TestHeader]
-        );
-
-        expect(routeParameters).toEqual([
-          {
-            $ref: '#/components/parameters/TestHeader',
-          },
-        ]);
+        expect(() =>
+          generateParamsForRoute(
+            {
+              request: { query: z.object({ test: TestHeader }) },
+            },
+            [TestHeader]
+          )
+        ).toThrowError(/^Conflicting location/);
       });
 
-      it('generates a reference query parameter for route', () => {
+      it('throws an error in case of name mismatch with reference', () => {
         const TestQuery = z.string().openapi({
           refId: 'TestQuery',
           param: { name: 'test', in: 'query' },
         });
 
-        const routeParameters = generateParamsForRoute(
-          {
-            request: { query: z.object({ test: TestQuery }) },
-          },
-          [TestQuery]
+        expect(() =>
+          generateParamsForRoute(
+            {
+              request: { query: z.object({ randomName: TestQuery }) },
+            },
+            [TestQuery]
+          )
+        ).toThrowError(/^Conflicting name/);
+      });
+
+      it('throws an error in case of missing name', () => {
+        expect(() =>
+          generateParamsForRoute({
+            request: { headers: [z.string()] },
+          })
+        ).toThrowError(/^Missing parameter data, please specify `name`/);
+      });
+
+      it('throws an error in case of missing location when registering a parameter', () => {
+        const TestQuery = z
+          .string()
+          .openapi({ refId: 'TestQuery', param: { name: 'test' } });
+
+        expect(() => generateParamsForRoute({}, [TestQuery])).toThrowError(
+          /^Missing parameter data, please specify `in`/
         );
-
-        expect(routeParameters).toEqual([
-          {
-            $ref: '#/components/parameters/TestQuery',
-          },
-        ]);
       });
-
-      describe('errors', () => {
-        it('throws an error in case of names mismatch', () => {
-          expect(() =>
-            generateParamsForRoute({
-              request: {
-                query: z.object({
-                  test: z.string().openapi({ param: { name: 'another' } }),
-                }),
-              },
-            })
-          ).toThrowError(/^Conflicting name/);
-        });
-
-        it('throws an error in case of location mismatch', () => {
-          expect(() =>
-            generateParamsForRoute({
-              request: {
-                query: z.object({
-                  test: z.string().openapi({ param: { in: 'header' } }),
-                }),
-              },
-            })
-          ).toThrowError(/^Conflicting location/);
-        });
-
-        it('throws an error in case of location mismatch with reference', () => {
-          const TestHeader = z.string().openapi({
-            refId: 'TestHeader',
-            param: { name: 'test', in: 'header' },
-          });
-
-          expect(() =>
-            generateParamsForRoute(
-              {
-                request: { query: z.object({ test: TestHeader }) },
-              },
-              [TestHeader]
-            )
-          ).toThrowError(/^Conflicting location/);
-        });
-
-        it('throws an error in case of name mismatch with reference', () => {
-          const TestQuery = z.string().openapi({
-            refId: 'TestQuery',
-            param: { name: 'test', in: 'query' },
-          });
-
-          expect(() =>
-            generateParamsForRoute(
-              {
-                request: { query: z.object({ randomName: TestQuery }) },
-              },
-              [TestQuery]
-            )
-          ).toThrowError(/^Conflicting name/);
-        });
-
-        it('throws an error in case of missing name', () => {
-          expect(() =>
-            generateParamsForRoute({
-              request: { headers: [z.string()] },
-            })
-          ).toThrowError(/^Missing parameter data, please specify `name`/);
-        });
-
-        it('throws an error in case of missing location when registering a parameter', () => {
-          const TestQuery = z
-            .string()
-            .openapi({ refId: 'TestQuery', param: { name: 'test' } });
-
-          expect(() => generateParamsForRoute({}, [TestQuery])).toThrowError(
-            /^Missing parameter data, please specify `in`/
-          );
-        });
-      });
-
-      function generateParamsForRoute(
-        props: Partial<RouteConfig> = {},
-        paramsToRegister?: ZodSchema<any>[]
-      ): OperationObject['parameters'] {
-        const route = createTestRoute(props);
-
-        const paramDefinitions =
-          paramsToRegister?.map(schema => ({
-            type: 'parameter' as const,
-            schema,
-          })) ?? [];
-
-        const routeDefinition = {
-          type: 'route' as const,
-          route,
-        };
-
-        const { paths } = new OpenAPIGenerator([
-          ...paramDefinitions,
-          routeDefinition,
-        ]).generateDocument(testDocConfig);
-
-        const routes = paths[route.path] as PathItemObject;
-
-        const routeDoc = routes[route.method];
-
-        return routeDoc?.parameters;
-      }
     });
 
-    describe('request body', () => {
-      it('can specify request body metadata - description/required', () => {
-        const registry = new OpenAPIRegistry();
+    function generateParamsForRoute(
+      props: Partial<RouteConfig> = {},
+      paramsToRegister?: ZodSchema<any>[]
+    ): OperationObject['parameters'] {
+      const route = createTestRoute(props);
 
-        const route = createTestRoute({
-          request: {
-            body: {
-              description: 'Test description',
-              required: true,
-              content: {
-                'application/json': {
-                  schema: z.string(),
-                },
+      const paramDefinitions =
+        paramsToRegister?.map(schema => ({
+          type: 'parameter' as const,
+          schema,
+        })) ?? [];
+
+      const routeDefinition = {
+        type: 'route' as const,
+        route,
+      };
+
+      const { paths } = new OpenAPIGenerator([
+        ...paramDefinitions,
+        routeDefinition,
+      ]).generateDocument(testDocConfig);
+
+      const routes = paths[route.path] as PathItemObject;
+
+      const routeDoc = routes[route.method];
+
+      return routeDoc?.parameters;
+    }
+  });
+
+  describe('request body', () => {
+    it('can specify request body metadata - description/required', () => {
+      const registry = new OpenAPIRegistry();
+
+      const route = createTestRoute({
+        request: {
+          body: {
+            description: 'Test description',
+            required: true,
+            content: {
+              'application/json': {
+                schema: z.string(),
               },
             },
           },
-        });
-
-        registry[registerFunction](route);
-
-        const document = new OpenAPIGenerator(
-          registry.definitions
-        ).generateDocument(testDocConfig);
-
-        const { requestBody } = document[rootDocPath]['/'].get;
-
-        expect(requestBody).toEqual({
-          description: 'Test description',
-          required: true,
-          content: { 'application/json': { schema: { type: 'string' } } },
-        });
+        },
       });
 
-      it('can specify request body using plain OpenApi format', () => {
-        const registry = new OpenAPIRegistry();
+      registry[registerFunction](route);
 
-        const route = createTestRoute({
-          request: {
-            body: {
-              content: {
-                'application/json': {
-                  schema: {
-                    type: 'string',
-                    enum: ['test'],
-                  },
-                },
-                'application/xml': {
-                  schema: { $ref: '#/components/schemas/SomeRef' },
-                },
-              },
-            },
-          },
-        });
+      const document = new OpenAPIGenerator(
+        registry.definitions
+      ).generateDocument(testDocConfig);
 
-        registry[registerFunction](route);
+      const { requestBody } = document[rootDocPath]['/'].get;
 
-        const document = new OpenAPIGenerator(
-          registry.definitions
-        ).generateDocument(testDocConfig);
-
-        const requestBody = document[rootDocPath]['/'].get.requestBody.content;
-
-        expect(requestBody['application/json']).toEqual({
-          schema: { type: 'string', enum: ['test'] },
-        });
-
-        expect(requestBody['application/xml']).toEqual({
-          schema: { $ref: '#/components/schemas/SomeRef' },
-        });
-      });
-
-      it('can have multiple media format bodies', () => {
-        const registry = new OpenAPIRegistry();
-
-        const UserSchema = registry.register(
-          'User',
-          z.object({ name: z.string() })
-        );
-
-        const route = createTestRoute({
-          request: {
-            body: {
-              content: {
-                'application/json': {
-                  schema: z.string(),
-                },
-                'application/xml': {
-                  schema: UserSchema,
-                },
-              },
-            },
-          },
-        });
-
-        registry[registerFunction](route);
-
-        const document = new OpenAPIGenerator(
-          registry.definitions
-        ).generateDocument(testDocConfig);
-
-        const requestBody = document[rootDocPath]['/'].get.requestBody.content;
-
-        expect(requestBody['application/json']).toEqual({
-          schema: { type: 'string' },
-        });
-
-        expect(requestBody['application/xml']).toEqual({
-          schema: { $ref: '#/components/schemas/User' },
-        });
+      expect(requestBody).toEqual({
+        description: 'Test description',
+        required: true,
+        content: { 'application/json': { schema: { type: 'string' } } },
       });
     });
-  }
-);
+
+    it('can specify request body using plain OpenApi format', () => {
+      const registry = new OpenAPIRegistry();
+
+      const route = createTestRoute({
+        request: {
+          body: {
+            content: {
+              'application/json': {
+                schema: {
+                  type: 'string',
+                  enum: ['test'],
+                },
+              },
+              'application/xml': {
+                schema: { $ref: '#/components/schemas/SomeRef' },
+              },
+            },
+          },
+        },
+      });
+
+      registry[registerFunction](route);
+
+      const document = new OpenAPIGenerator(
+        registry.definitions
+      ).generateDocument(testDocConfig);
+
+      const requestBody = document[rootDocPath]['/'].get.requestBody.content;
+
+      expect(requestBody['application/json']).toEqual({
+        schema: { type: 'string', enum: ['test'] },
+      });
+
+      expect(requestBody['application/xml']).toEqual({
+        schema: { $ref: '#/components/schemas/SomeRef' },
+      });
+    });
+
+    it('can have multiple media format bodies', () => {
+      const registry = new OpenAPIRegistry();
+
+      const UserSchema = registry.register(
+        'User',
+        z.object({ name: z.string() })
+      );
+
+      const route = createTestRoute({
+        request: {
+          body: {
+            content: {
+              'application/json': {
+                schema: z.string(),
+              },
+              'application/xml': {
+                schema: UserSchema,
+              },
+            },
+          },
+        },
+      });
+
+      registry[registerFunction](route);
+
+      const document = new OpenAPIGenerator(
+        registry.definitions
+      ).generateDocument(testDocConfig);
+
+      const requestBody = document[rootDocPath]['/'].get.requestBody.content;
+
+      expect(requestBody['application/json']).toEqual({
+        schema: { type: 'string' },
+      });
+
+      expect(requestBody['application/xml']).toEqual({
+        schema: { $ref: '#/components/schemas/User' },
+      });
+    });
+  });
+};
+
+describe.each`
+  type          | registerFunction     | rootDocPath
+  ${'Routes'}   | ${'registerPath'}    | ${'paths'}
+  ${'Webhooks'} | ${'registerWebhook'} | ${'webhooks'}
+`('$type', routeTests);

--- a/spec/routes.spec.ts
+++ b/spec/routes.spec.ts
@@ -31,459 +31,474 @@ const testDocConfig = {
   servers: [{ url: 'v1' }],
 };
 
-describe('Routes', () => {
-  describe('response definitions', () => {
-    it('can set description', () => {
-      const registry = new OpenAPIRegistry();
+describe.each`
+  type          | registerFunction     | rootDocPath
+  ${'Routes'}   | ${'registerPath'}    | ${'paths'}
+  ${'Webhooks'} | ${'registerWebhook'} | ${'webhooks'}
+`(
+  '$type',
+  ({
+    registerFunction,
+    rootDocPath,
+  }: {
+    registerFunction: 'registerPath' | 'registerWebhook';
+    rootDocPath: 'paths' | 'webhooks';
+  }) => {
+    describe('response definitions', () => {
+      it('can set description', () => {
+        const registry = new OpenAPIRegistry();
 
-      registry.registerPath({
-        method: 'get',
-        path: '/',
-        responses: {
-          200: {
-            description: 'Simple response',
-            content: {
-              'application/json': {
-                schema: z.string(),
+        registry[registerFunction]({
+          method: 'get',
+          path: '/',
+          responses: {
+            200: {
+              description: 'Simple response',
+              content: {
+                'application/json': {
+                  schema: z.string(),
+                },
               },
             },
-          },
 
-          404: {
-            description: 'Missing object',
-            content: {
-              'application/json': {
-                schema: z.string(),
-              },
-            },
-          },
-        },
-      });
-
-      const document = new OpenAPIGenerator(
-        registry.definitions
-      ).generateDocument(testDocConfig);
-      const responses = document.paths['/'].get.responses;
-
-      expect(responses['200'].description).toEqual('Simple response');
-      expect(responses['404'].description).toEqual('Missing object');
-    });
-
-    it('can specify response with plain OpenApi format', () => {
-      const registry = new OpenAPIRegistry();
-
-      registry.registerPath({
-        method: 'get',
-        path: '/',
-        responses: {
-          200: {
-            description: 'Simple response',
-            content: {
-              'application/json': {
-                schema: {
-                  type: 'string',
-                  example: 'test',
+            404: {
+              description: 'Missing object',
+              content: {
+                'application/json': {
+                  schema: z.string(),
                 },
               },
             },
           },
+        });
 
-          404: {
-            description: 'Missing object',
-            content: {
-              'application/json': {
-                schema: {
-                  $ref: '#/components/schemas/SomeRef',
+        const document = new OpenAPIGenerator(
+          registry.definitions
+        ).generateDocument(testDocConfig);
+        const responses = document[rootDocPath]['/'].get.responses;
+
+        expect(responses['200'].description).toEqual('Simple response');
+        expect(responses['404'].description).toEqual('Missing object');
+      });
+
+      it('can specify response with plain OpenApi format', () => {
+        const registry = new OpenAPIRegistry();
+
+        registry[registerFunction]({
+          method: 'get',
+          path: '/',
+          responses: {
+            200: {
+              description: 'Simple response',
+              content: {
+                'application/json': {
+                  schema: {
+                    type: 'string',
+                    example: 'test',
+                  },
+                },
+              },
+            },
+
+            404: {
+              description: 'Missing object',
+              content: {
+                'application/json': {
+                  schema: {
+                    $ref: '#/components/schemas/SomeRef',
+                  },
                 },
               },
             },
           },
-        },
+        });
+
+        const document = new OpenAPIGenerator(
+          registry.definitions
+        ).generateDocument(testDocConfig);
+        const responses = document[rootDocPath]['/'].get.responses;
+
+        expect(responses['200'].content['application/json'].schema).toEqual({
+          type: 'string',
+          example: 'test',
+        });
+        expect(responses['404'].content['application/json'].schema).toEqual({
+          $ref: '#/components/schemas/SomeRef',
+        });
       });
 
-      const document = new OpenAPIGenerator(
-        registry.definitions
-      ).generateDocument(testDocConfig);
-      const responses = document.paths['/'].get.responses;
+      it('can set multiple response formats', () => {
+        const registry = new OpenAPIRegistry();
 
-      expect(responses['200'].content['application/json'].schema).toEqual({
-        type: 'string',
-        example: 'test',
-      });
-      expect(responses['404'].content['application/json'].schema).toEqual({
-        $ref: '#/components/schemas/SomeRef',
-      });
-    });
+        const UserSchema = registry.register(
+          'User',
+          z.object({ name: z.string() })
+        );
 
-    it('can set multiple response formats', () => {
-      const registry = new OpenAPIRegistry();
-
-      const UserSchema = registry.register(
-        'User',
-        z.object({ name: z.string() })
-      );
-
-      registry.registerPath({
-        method: 'get',
-        path: '/',
-        responses: {
-          200: {
-            description: 'Simple response',
-            content: {
-              'application/json': {
-                schema: UserSchema,
+        registry[registerFunction]({
+          method: 'get',
+          path: '/',
+          responses: {
+            200: {
+              description: 'Simple response',
+              content: {
+                'application/json': {
+                  schema: UserSchema,
+                },
+                'application/xml': {
+                  schema: UserSchema,
+                },
               },
-              'application/xml': {
-                schema: UserSchema,
-              },
             },
           },
-        },
+        });
+
+        const document = new OpenAPIGenerator(
+          registry.definitions
+        ).generateDocument(testDocConfig);
+        const responses = document[rootDocPath]['/'].get.responses;
+
+        expect(responses['200'].description).toEqual('Simple response');
+        expect(responses['200'].content['application/json'].schema).toEqual({
+          $ref: '#/components/schemas/User',
+        });
+        expect(responses['200'].content['application/xml'].schema).toEqual({
+          $ref: '#/components/schemas/User',
+        });
       });
 
-      const document = new OpenAPIGenerator(
-        registry.definitions
-      ).generateDocument(testDocConfig);
-      const responses = document.paths['/'].get.responses;
+      it('can generate responses without content', () => {
+        const registry = new OpenAPIRegistry();
 
-      expect(responses['200'].description).toEqual('Simple response');
-      expect(responses['200'].content['application/json'].schema).toEqual({
-        $ref: '#/components/schemas/User',
-      });
-      expect(responses['200'].content['application/xml'].schema).toEqual({
-        $ref: '#/components/schemas/User',
-      });
-    });
-
-    it('can generate responses without content', () => {
-      const registry = new OpenAPIRegistry();
-
-      registry.registerPath({
-        method: 'get',
-        path: '/',
-        responses: {
-          204: {
-            description: 'Success',
-          },
-        },
-      });
-
-      const document = new OpenAPIGenerator(
-        registry.definitions
-      ).generateDocument(testDocConfig);
-      const responses = document.paths['/'].get.responses;
-
-      expect(responses['204']).toEqual({ description: 'Success' });
-    });
-  });
-
-  describe('parameters', () => {
-    it('generates a query parameter for route', () => {
-      const routeParameters = generateParamsForRoute({
-        request: { query: z.object({ test: z.string() }) },
-      });
-
-      expect(routeParameters).toEqual([
-        {
-          in: 'query',
-          name: 'test',
-          required: true,
-          schema: {
-            type: 'string',
-          },
-        },
-      ]);
-    });
-
-    it('generates a path parameter for route', () => {
-      const routeParameters = generateParamsForRoute({
-        request: { params: z.object({ test: z.string() }) },
-      });
-
-      expect(routeParameters).toEqual([
-        {
-          in: 'path',
-          name: 'test',
-          required: true,
-          schema: {
-            type: 'string',
-          },
-        },
-      ]);
-    });
-
-    it('generates a header parameter for route', () => {
-      const routeParameters = generateParamsForRoute({
-        request: { headers: [z.string().openapi({ param: { name: 'test' } })] },
-      });
-
-      expect(routeParameters).toEqual([
-        {
-          in: 'header',
-          name: 'test',
-          required: true,
-          schema: {
-            type: 'string',
-          },
-        },
-      ]);
-    });
-
-    it('generates a reference header parameter for route', () => {
-      const TestHeader = z.string().openapi({
-        refId: 'TestHeader',
-        param: { name: 'test', in: 'header' },
-      });
-
-      const routeParameters = generateParamsForRoute(
-        {
-          request: { headers: [TestHeader] },
-        },
-        [TestHeader]
-      );
-
-      expect(routeParameters).toEqual([
-        {
-          $ref: '#/components/parameters/TestHeader',
-        },
-      ]);
-    });
-
-    it('generates a reference query parameter for route', () => {
-      const TestQuery = z.string().openapi({
-        refId: 'TestQuery',
-        param: { name: 'test', in: 'query' },
-      });
-
-      const routeParameters = generateParamsForRoute(
-        {
-          request: { query: z.object({ test: TestQuery }) },
-        },
-        [TestQuery]
-      );
-
-      expect(routeParameters).toEqual([
-        {
-          $ref: '#/components/parameters/TestQuery',
-        },
-      ]);
-    });
-
-    describe('errors', () => {
-      it('throws an error in case of names mismatch', () => {
-        expect(() =>
-          generateParamsForRoute({
-            request: {
-              query: z.object({
-                test: z.string().openapi({ param: { name: 'another' } }),
-              }),
+        registry[registerFunction]({
+          method: 'get',
+          path: '/',
+          responses: {
+            204: {
+              description: 'Success',
             },
-          })
-        ).toThrowError(/^Conflicting name/);
-      });
+          },
+        });
 
-      it('throws an error in case of location mismatch', () => {
-        expect(() =>
-          generateParamsForRoute({
-            request: {
-              query: z.object({
-                test: z.string().openapi({ param: { in: 'header' } }),
-              }),
+        const document = new OpenAPIGenerator(
+          registry.definitions
+        ).generateDocument(testDocConfig);
+        const responses = document[rootDocPath]['/'].get.responses;
+
+        expect(responses['204']).toEqual({ description: 'Success' });
+      });
+    });
+
+    describe('parameters', () => {
+      it('generates a query parameter for route', () => {
+        const routeParameters = generateParamsForRoute({
+          request: { query: z.object({ test: z.string() }) },
+        });
+
+        expect(routeParameters).toEqual([
+          {
+            in: 'query',
+            name: 'test',
+            required: true,
+            schema: {
+              type: 'string',
             },
-          })
-        ).toThrowError(/^Conflicting location/);
+          },
+        ]);
       });
 
-      it('throws an error in case of location mismatch with reference', () => {
+      it('generates a path parameter for route', () => {
+        const routeParameters = generateParamsForRoute({
+          request: { params: z.object({ test: z.string() }) },
+        });
+
+        expect(routeParameters).toEqual([
+          {
+            in: 'path',
+            name: 'test',
+            required: true,
+            schema: {
+              type: 'string',
+            },
+          },
+        ]);
+      });
+
+      it('generates a header parameter for route', () => {
+        const routeParameters = generateParamsForRoute({
+          request: {
+            headers: [z.string().openapi({ param: { name: 'test' } })],
+          },
+        });
+
+        expect(routeParameters).toEqual([
+          {
+            in: 'header',
+            name: 'test',
+            required: true,
+            schema: {
+              type: 'string',
+            },
+          },
+        ]);
+      });
+
+      it('generates a reference header parameter for route', () => {
         const TestHeader = z.string().openapi({
           refId: 'TestHeader',
           param: { name: 'test', in: 'header' },
         });
 
-        expect(() =>
-          generateParamsForRoute(
-            {
-              request: { query: z.object({ test: TestHeader }) },
-            },
-            [TestHeader]
-          )
-        ).toThrowError(/^Conflicting location/);
+        const routeParameters = generateParamsForRoute(
+          {
+            request: { headers: [TestHeader] },
+          },
+          [TestHeader]
+        );
+
+        expect(routeParameters).toEqual([
+          {
+            $ref: '#/components/parameters/TestHeader',
+          },
+        ]);
       });
 
-      it('throws an error in case of name mismatch with reference', () => {
+      it('generates a reference query parameter for route', () => {
         const TestQuery = z.string().openapi({
           refId: 'TestQuery',
           param: { name: 'test', in: 'query' },
         });
 
-        expect(() =>
-          generateParamsForRoute(
-            {
-              request: { query: z.object({ randomName: TestQuery }) },
-            },
-            [TestQuery]
-          )
-        ).toThrowError(/^Conflicting name/);
-      });
-
-      it('throws an error in case of missing name', () => {
-        expect(() =>
-          generateParamsForRoute({
-            request: { headers: [z.string()] },
-          })
-        ).toThrowError(/^Missing parameter data, please specify `name`/);
-      });
-
-      it('throws an error in case of missing location when registering a parameter', () => {
-        const TestQuery = z
-          .string()
-          .openapi({ refId: 'TestQuery', param: { name: 'test' } });
-
-        expect(() => generateParamsForRoute({}, [TestQuery])).toThrowError(
-          /^Missing parameter data, please specify `in`/
-        );
-      });
-    });
-
-    function generateParamsForRoute(
-      props: Partial<RouteConfig> = {},
-      paramsToRegister?: ZodSchema<any>[]
-    ): OperationObject['parameters'] {
-      const route = createTestRoute(props);
-
-      const paramDefinitions =
-        paramsToRegister?.map(schema => ({
-          type: 'parameter' as const,
-          schema,
-        })) ?? [];
-
-      const routeDefinition = {
-        type: 'route' as const,
-        route,
-      };
-
-      const { paths } = new OpenAPIGenerator([
-        ...paramDefinitions,
-        routeDefinition,
-      ]).generateDocument(testDocConfig);
-
-      const routes = paths[route.path] as PathItemObject;
-
-      const routeDoc = routes[route.method];
-
-      return routeDoc?.parameters;
-    }
-  });
-
-  describe('request body', () => {
-    it('can specify request body metadata - description/required', () => {
-      const registry = new OpenAPIRegistry();
-
-      const route = createTestRoute({
-        request: {
-          body: {
-            description: 'Test description',
-            required: true,
-            content: {
-              'application/json': {
-                schema: z.string(),
-              },
-            },
+        const routeParameters = generateParamsForRoute(
+          {
+            request: { query: z.object({ test: TestQuery }) },
           },
-        },
+          [TestQuery]
+        );
+
+        expect(routeParameters).toEqual([
+          {
+            $ref: '#/components/parameters/TestQuery',
+          },
+        ]);
       });
 
-      registry.registerPath(route);
+      describe('errors', () => {
+        it('throws an error in case of names mismatch', () => {
+          expect(() =>
+            generateParamsForRoute({
+              request: {
+                query: z.object({
+                  test: z.string().openapi({ param: { name: 'another' } }),
+                }),
+              },
+            })
+          ).toThrowError(/^Conflicting name/);
+        });
 
-      const document = new OpenAPIGenerator(
-        registry.definitions
-      ).generateDocument(testDocConfig);
+        it('throws an error in case of location mismatch', () => {
+          expect(() =>
+            generateParamsForRoute({
+              request: {
+                query: z.object({
+                  test: z.string().openapi({ param: { in: 'header' } }),
+                }),
+              },
+            })
+          ).toThrowError(/^Conflicting location/);
+        });
 
-      const { requestBody } = document.paths['/'].get;
+        it('throws an error in case of location mismatch with reference', () => {
+          const TestHeader = z.string().openapi({
+            refId: 'TestHeader',
+            param: { name: 'test', in: 'header' },
+          });
 
-      expect(requestBody).toEqual({
-        description: 'Test description',
-        required: true,
-        content: { 'application/json': { schema: { type: 'string' } } },
+          expect(() =>
+            generateParamsForRoute(
+              {
+                request: { query: z.object({ test: TestHeader }) },
+              },
+              [TestHeader]
+            )
+          ).toThrowError(/^Conflicting location/);
+        });
+
+        it('throws an error in case of name mismatch with reference', () => {
+          const TestQuery = z.string().openapi({
+            refId: 'TestQuery',
+            param: { name: 'test', in: 'query' },
+          });
+
+          expect(() =>
+            generateParamsForRoute(
+              {
+                request: { query: z.object({ randomName: TestQuery }) },
+              },
+              [TestQuery]
+            )
+          ).toThrowError(/^Conflicting name/);
+        });
+
+        it('throws an error in case of missing name', () => {
+          expect(() =>
+            generateParamsForRoute({
+              request: { headers: [z.string()] },
+            })
+          ).toThrowError(/^Missing parameter data, please specify `name`/);
+        });
+
+        it('throws an error in case of missing location when registering a parameter', () => {
+          const TestQuery = z
+            .string()
+            .openapi({ refId: 'TestQuery', param: { name: 'test' } });
+
+          expect(() => generateParamsForRoute({}, [TestQuery])).toThrowError(
+            /^Missing parameter data, please specify `in`/
+          );
+        });
       });
+
+      function generateParamsForRoute(
+        props: Partial<RouteConfig> = {},
+        paramsToRegister?: ZodSchema<any>[]
+      ): OperationObject['parameters'] {
+        const route = createTestRoute(props);
+
+        const paramDefinitions =
+          paramsToRegister?.map(schema => ({
+            type: 'parameter' as const,
+            schema,
+          })) ?? [];
+
+        const routeDefinition = {
+          type: 'route' as const,
+          route,
+        };
+
+        const { paths } = new OpenAPIGenerator([
+          ...paramDefinitions,
+          routeDefinition,
+        ]).generateDocument(testDocConfig);
+
+        const routes = paths[route.path] as PathItemObject;
+
+        const routeDoc = routes[route.method];
+
+        return routeDoc?.parameters;
+      }
     });
 
-    it('can specify request body using plain OpenApi format', () => {
-      const registry = new OpenAPIRegistry();
+    describe('request body', () => {
+      it('can specify request body metadata - description/required', () => {
+        const registry = new OpenAPIRegistry();
 
-      const route = createTestRoute({
-        request: {
-          body: {
-            content: {
-              'application/json': {
-                schema: {
-                  type: 'string',
-                  enum: ['test'],
+        const route = createTestRoute({
+          request: {
+            body: {
+              description: 'Test description',
+              required: true,
+              content: {
+                'application/json': {
+                  schema: z.string(),
                 },
               },
-              'application/xml': {
-                schema: { $ref: '#/components/schemas/SomeRef' },
+            },
+          },
+        });
+
+        registry[registerFunction](route);
+
+        const document = new OpenAPIGenerator(
+          registry.definitions
+        ).generateDocument(testDocConfig);
+
+        const { requestBody } = document[rootDocPath]['/'].get;
+
+        expect(requestBody).toEqual({
+          description: 'Test description',
+          required: true,
+          content: { 'application/json': { schema: { type: 'string' } } },
+        });
+      });
+
+      it('can specify request body using plain OpenApi format', () => {
+        const registry = new OpenAPIRegistry();
+
+        const route = createTestRoute({
+          request: {
+            body: {
+              content: {
+                'application/json': {
+                  schema: {
+                    type: 'string',
+                    enum: ['test'],
+                  },
+                },
+                'application/xml': {
+                  schema: { $ref: '#/components/schemas/SomeRef' },
+                },
               },
             },
           },
-        },
+        });
+
+        registry[registerFunction](route);
+
+        const document = new OpenAPIGenerator(
+          registry.definitions
+        ).generateDocument(testDocConfig);
+
+        const requestBody = document[rootDocPath]['/'].get.requestBody.content;
+
+        expect(requestBody['application/json']).toEqual({
+          schema: { type: 'string', enum: ['test'] },
+        });
+
+        expect(requestBody['application/xml']).toEqual({
+          schema: { $ref: '#/components/schemas/SomeRef' },
+        });
       });
 
-      registry.registerPath(route);
+      it('can have multiple media format bodies', () => {
+        const registry = new OpenAPIRegistry();
 
-      const document = new OpenAPIGenerator(
-        registry.definitions
-      ).generateDocument(testDocConfig);
+        const UserSchema = registry.register(
+          'User',
+          z.object({ name: z.string() })
+        );
 
-      const requestBody = document.paths['/'].get.requestBody.content;
-
-      expect(requestBody['application/json']).toEqual({
-        schema: { type: 'string', enum: ['test'] },
-      });
-
-      expect(requestBody['application/xml']).toEqual({
-        schema: { $ref: '#/components/schemas/SomeRef' },
-      });
-    });
-
-    it('can have multiple media format bodies', () => {
-      const registry = new OpenAPIRegistry();
-
-      const UserSchema = registry.register(
-        'User',
-        z.object({ name: z.string() })
-      );
-
-      const route = createTestRoute({
-        request: {
-          body: {
-            content: {
-              'application/json': {
-                schema: z.string(),
-              },
-              'application/xml': {
-                schema: UserSchema,
+        const route = createTestRoute({
+          request: {
+            body: {
+              content: {
+                'application/json': {
+                  schema: z.string(),
+                },
+                'application/xml': {
+                  schema: UserSchema,
+                },
               },
             },
           },
-        },
-      });
+        });
 
-      registry.registerPath(route);
+        registry[registerFunction](route);
 
-      const document = new OpenAPIGenerator(
-        registry.definitions
-      ).generateDocument(testDocConfig);
+        const document = new OpenAPIGenerator(
+          registry.definitions
+        ).generateDocument(testDocConfig);
 
-      const requestBody = document.paths['/'].get.requestBody.content;
+        const requestBody = document[rootDocPath]['/'].get.requestBody.content;
 
-      expect(requestBody['application/json']).toEqual({
-        schema: { type: 'string' },
-      });
+        expect(requestBody['application/json']).toEqual({
+          schema: { type: 'string' },
+        });
 
-      expect(requestBody['application/xml']).toEqual({
-        schema: { $ref: '#/components/schemas/User' },
+        expect(requestBody['application/xml']).toEqual({
+          schema: { $ref: '#/components/schemas/User' },
+        });
       });
     });
-  });
-});
+  }
+);

--- a/src/openapi-generator.ts
+++ b/src/openapi-generator.ts
@@ -93,7 +93,7 @@ export class OpenAPIGenerator {
       ...config,
       components: this.buildComponents(),
       paths: this.pathRefs,
-      // As this is invalid in Open API 3.0 we optionally set it
+      // As the `webhooks` key is invalid in Open API 3.0.x we need to optionally set it
       ...(Object.keys(this.webhookRefs).length && {
         webhooks: this.webhookRefs,
       }),
@@ -157,11 +157,8 @@ export class OpenAPIGenerator {
         return;
 
       case 'route':
-        this.generateSingleRoute(definition.type, definition.route);
-        return;
-
       case 'webhook':
-        this.generateSingleRoute(definition.type, definition.webhook);
+        this.generateSingleRoute(definition.type, definition.route);
         return;
 
       case 'component':
@@ -483,18 +480,24 @@ export class OpenAPIGenerator {
       },
     };
 
-    if (type === 'route') {
-      this.pathRefs[path] = {
-        ...this.pathRefs[path],
-        ...routeDoc,
-      };
-    }
-
-    if (type === 'webhook') {
-      this.webhookRefs[path] = {
-        ...this.webhookRefs[path],
-        ...routeDoc,
-      };
+    switch (type) {
+      case 'route': {
+        this.pathRefs[path] = {
+          ...this.pathRefs[path],
+          ...routeDoc,
+        };
+        break;
+      }
+      case 'webhook': {
+        this.webhookRefs[path] = {
+          ...this.webhookRefs[path],
+          ...routeDoc,
+        };
+        break;
+      }
+      default: {
+        throw new Error(`Unknown type: ${type} was received`);
+      }
     }
 
     return routeDoc;

--- a/src/openapi-generator.ts
+++ b/src/openapi-generator.ts
@@ -157,8 +157,11 @@ export class OpenAPIGenerator {
         return;
 
       case 'route':
+        this.generateSingleRoute(definition.route);
+        return;
+
       case 'webhook':
-        this.generateSingleRoute(definition.type, definition.route);
+        this.generateSingleWebhook(definition.webhook);
         return;
 
       case 'component':
@@ -458,7 +461,7 @@ export class OpenAPIGenerator {
     return [...pathParameters, ...queryParameters, ...headerParameters];
   }
 
-  private generateSingleRoute(type: 'webhook' | 'route', route: RouteConfig) {
+  private generatePath(route: RouteConfig): PathItemObject {
     const { method, path, request, responses, ...pathItemConfig } = route;
 
     const generatedResponses = mapValues(responses, response => {
@@ -480,26 +483,24 @@ export class OpenAPIGenerator {
       },
     };
 
-    switch (type) {
-      case 'route': {
-        this.pathRefs[path] = {
-          ...this.pathRefs[path],
-          ...routeDoc,
-        };
-        break;
-      }
-      case 'webhook': {
-        this.webhookRefs[path] = {
-          ...this.webhookRefs[path],
-          ...routeDoc,
-        };
-        break;
-      }
-      default: {
-        throw new Error(`Unknown type: ${type} was received`);
-      }
-    }
+    return routeDoc;
+  }
 
+  private generateSingleRoute(route: RouteConfig): PathItemObject {
+    const routeDoc = this.generatePath(route);
+    this.pathRefs[route.path] = {
+      ...this.pathRefs[route.path],
+      ...routeDoc,
+    };
+    return routeDoc;
+  }
+
+  private generateSingleWebhook(route: RouteConfig): PathItemObject {
+    const routeDoc = this.generatePath(route);
+    this.webhookRefs[route.path] = {
+      ...this.webhookRefs[route.path],
+      ...routeDoc,
+    };
     return routeDoc;
   }
 

--- a/src/openapi-registry.ts
+++ b/src/openapi-registry.ts
@@ -85,7 +85,8 @@ export type OpenAPIDefinitions =
     }
   | { type: 'schema'; schema: ZodSchema<any> }
   | { type: 'parameter'; schema: ZodSchema<any> }
-  | { type: 'route'; route: RouteConfig };
+  | { type: 'route'; route: RouteConfig }
+  | { type: 'webhook'; webhook: RouteConfig };
 
 export class OpenAPIRegistry {
   private _definitions: OpenAPIDefinitions[] = [];
@@ -144,6 +145,16 @@ export class OpenAPIRegistry {
     this._definitions.push({
       type: 'route',
       route,
+    });
+  }
+
+  /**
+   * Registers a new webhook that would be generated under webhooks:
+   */
+  registerWebhook(webhook: RouteConfig) {
+    this._definitions.push({
+      type: 'webhook',
+      webhook,
     });
   }
 

--- a/src/openapi-registry.ts
+++ b/src/openapi-registry.ts
@@ -86,7 +86,7 @@ export type OpenAPIDefinitions =
   | { type: 'schema'; schema: ZodSchema<any> }
   | { type: 'parameter'; schema: ZodSchema<any> }
   | { type: 'route'; route: RouteConfig }
-  | { type: 'webhook'; route: RouteConfig };
+  | { type: 'webhook'; webhook: RouteConfig };
 
 export class OpenAPIRegistry {
   private _definitions: OpenAPIDefinitions[] = [];
@@ -151,10 +151,10 @@ export class OpenAPIRegistry {
   /**
    * Registers a new webhook that would be generated under webhooks:
    */
-  registerWebhook(route: RouteConfig) {
+  registerWebhook(webhook: RouteConfig) {
     this._definitions.push({
       type: 'webhook',
-      route,
+      webhook,
     });
   }
 

--- a/src/openapi-registry.ts
+++ b/src/openapi-registry.ts
@@ -86,7 +86,7 @@ export type OpenAPIDefinitions =
   | { type: 'schema'; schema: ZodSchema<any> }
   | { type: 'parameter'; schema: ZodSchema<any> }
   | { type: 'route'; route: RouteConfig }
-  | { type: 'webhook'; webhook: RouteConfig };
+  | { type: 'webhook'; route: RouteConfig };
 
 export class OpenAPIRegistry {
   private _definitions: OpenAPIDefinitions[] = [];
@@ -151,10 +151,10 @@ export class OpenAPIRegistry {
   /**
    * Registers a new webhook that would be generated under webhooks:
    */
-  registerWebhook(webhook: RouteConfig) {
+  registerWebhook(route: RouteConfig) {
     this._definitions.push({
       type: 'webhook',
-      webhook,
+      route,
     });
   }
 


### PR DESCRIPTION
Hola! :) 

Open API 3.1 added `webhooks` which allow you to define event schema using the same route path objects that you can define paths with.
https://github.com/OAI/OpenAPI-Specification/blob/main/examples/v3.1/webhook-example.yaml

Adding support for Webhooks. I've also tested this on my current project and it produces schema which I validated successfully against the Open API 3.1 schema.

