### PR TITLE
Add discriminator key to ZodDiscriminatedUnion schemas

### DIFF
--- a/README.md
+++ b/README.md
@@ -371,6 +371,8 @@ The list of all supported types as of now is:
 - `ZodNativeEnum`
 - `ZodObject`
 - `ZodArray`
+- `ZodDiscriminatedUnion`
+  - including `discriminator` mapping when all Zod objects in the union are registered with `.register()` or contain a `refId`.
 - `ZodUnion`
 - `ZodIntersection`
 - `ZodRecord`

--- a/spec/types/discriminated-union.spec.ts
+++ b/spec/types/discriminated-union.spec.ts
@@ -2,7 +2,7 @@ import { z } from 'zod';
 import { expectSchema } from '../lib/helpers';
 
 describe('discriminated union', () => {
-  it('supports discriminated unions', () => {
+  it('supports basic discriminated unions', () => {
     const Text = z.object({ type: z.literal('text'), text: z.string() });
     const Image = z.object({ type: z.literal('image'), src: z.string() });
 
@@ -28,8 +28,91 @@ describe('discriminated union', () => {
               },
             },
           ],
+        },
+      }
+    );
+  });
+
+  it('creates a discriminator mapping when all objects in the discriminated union contain a registered schema', () => {
+    const Text = z
+      .object({ type: z.literal('text'), text: z.string() })
+      .openapi({ refId: 'obj1' });
+    const Image = z
+      .object({ type: z.literal('image'), src: z.string() })
+      .openapi({ refId: 'obj2' });
+
+    expectSchema(
+      [
+        Text,
+        Image,
+        z.discriminatedUnion('type', [Text, Image]).openapi({ refId: 'Test' }),
+      ],
+      {
+        Test: {
+          oneOf: [
+            { $ref: '#/components/schemas/obj1' },
+            { $ref: '#/components/schemas/obj2' },
+          ],
           discriminator: {
             propertyName: 'type',
+            mapping: {
+              text: '#/components/schemas/obj1',
+              image: '#/components/schemas/obj2',
+            },
+          },
+        },
+        obj1: {
+          type: 'object',
+          required: ['type', 'text'],
+          properties: {
+            type: { type: 'string', enum: ['text'] },
+            text: { type: 'string' },
+          },
+        },
+        obj2: {
+          type: 'object',
+          required: ['type', 'src'],
+          properties: {
+            type: { type: 'string', enum: ['image'] },
+            src: { type: 'string' },
+          },
+        },
+      }
+    );
+  });
+
+  it('does not create a discriminator mapping when only some objects in the discriminated union contain a registered schema', () => {
+    const Text = z
+      .object({ type: z.literal('text'), text: z.string() })
+      .openapi({ refId: 'obj1' });
+    const Image = z.object({ type: z.literal('image'), src: z.string() });
+
+    expectSchema(
+      [
+        Text,
+        Image,
+        z.discriminatedUnion('type', [Text, Image]).openapi({ refId: 'Test' }),
+      ],
+      {
+        Test: {
+          oneOf: [
+            { $ref: '#/components/schemas/obj1' },
+            {
+              type: 'object',
+              required: ['type', 'src'],
+              properties: {
+                type: { type: 'string', enum: ['image'] },
+                src: { type: 'string' },
+              },
+            },
+          ],
+        },
+        obj1: {
+          type: 'object',
+          required: ['type', 'text'],
+          properties: {
+            type: { type: 'string', enum: ['text'] },
+            text: { type: 'string' },
           },
         },
       }

--- a/spec/types/discriminated-union.spec.ts
+++ b/spec/types/discriminated-union.spec.ts
@@ -10,7 +10,7 @@ describe('discriminated union', () => {
       [z.discriminatedUnion('type', [Text, Image]).openapi({ refId: 'Test' })],
       {
         Test: {
-          anyOf: [
+          oneOf: [
             {
               type: 'object',
               required: ['type', 'text'],
@@ -28,6 +28,9 @@ describe('discriminated union', () => {
               },
             },
           ],
+          discriminator: {
+            propertyName: 'type',
+          },
         },
       }
     );

--- a/src/openapi-generator.ts
+++ b/src/openapi-generator.ts
@@ -18,6 +18,7 @@ import {
   DiscriminatorObject,
 } from 'openapi3-ts';
 import type {
+  map,
   ZodObject,
   ZodRawShape,
   ZodSchema,
@@ -579,8 +580,14 @@ export class OpenAPIGenerator {
     }
 
     const mapping = zodObjects.reduce((map, obj) => {
-      // Zod type checks each object in the discriminated union so we can trust this is available.
-      const value = obj.shape?.[discriminator]?._def.value as string;
+      const value = obj.shape?.[discriminator]?._def.value;
+
+      // This should never happen because Zod checks the disciminator type but to keep the types happy
+      if (typeof value !== 'string') {
+        throw new Error(
+          `Discriminator ${discriminator} could not be found in one of the values of a discriminated union`
+        );
+      }
 
       map[value] = `#/components/schemas/${obj._def.openapi?.refId as string}`;
       return map;

--- a/src/openapi-generator.ts
+++ b/src/openapi-generator.ts
@@ -18,7 +18,6 @@ import {
   DiscriminatorObject,
 } from 'openapi3-ts';
 import type {
-  map,
   ZodObject,
   ZodRawShape,
   ZodSchema,

--- a/src/openapi-generator.ts
+++ b/src/openapi-generator.ts
@@ -579,7 +579,7 @@ export class OpenAPIGenerator {
     }
 
     const mapping: Record<string, string> = {};
-    zodObjects.forEach((obj) => {
+    zodObjects.forEach(obj => {
       const value = obj.shape?.[discriminator]?._def.value;
 
       // This should never happen because Zod checks the disciminator type but to keep the types happy
@@ -589,7 +589,9 @@ export class OpenAPIGenerator {
         );
       }
 
-      mapping[value] = `#/components/schemas/${obj._def.openapi?.refId as string}`;
+      mapping[value] = `#/components/schemas/${
+        obj._def.openapi?.refId as string
+      }`;
     });
 
     return {

--- a/src/openapi-generator.ts
+++ b/src/openapi-generator.ts
@@ -578,7 +578,8 @@ export class OpenAPIGenerator {
       return undefined;
     }
 
-    const mapping = zodObjects.reduce((map, obj) => {
+    const mapping: Record<string, string> = {};
+    zodObjects.forEach((obj) => {
       const value = obj.shape?.[discriminator]?._def.value;
 
       // This should never happen because Zod checks the disciminator type but to keep the types happy
@@ -588,9 +589,8 @@ export class OpenAPIGenerator {
         );
       }
 
-      map[value] = `#/components/schemas/${obj._def.openapi?.refId as string}`;
-      return map;
-    }, {} as Record<string, string>);
+      mapping[value] = `#/components/schemas/${obj._def.openapi?.refId as string}`;
+    });
 
     return {
       propertyName: discriminator,

--- a/src/openapi-generator.ts
+++ b/src/openapi-generator.ts
@@ -685,7 +685,8 @@ export class OpenAPIGenerator {
       const options = [...zodSchema.options.values()];
 
       return {
-        anyOf: options.map(schema => this.generateInnerSchema(schema)),
+        oneOf: options.map(schema => this.generateInnerSchema(schema)),
+        discriminator: { propertyName: zodSchema.discriminator },
       };
     }
 


### PR DESCRIPTION
- Adds the `discriminator` key to discriminated unions generated schema only when a user has registered the schemas.
  - Added `mapping` for convenience for the user.
- Change the type of discriminated union to `oneOf`.

https://swagger.io/docs/specification/data-models/inheritance-and-polymorphism/

<img width="1481" alt="image" src="https://user-images.githubusercontent.com/18017094/195346662-2bbc8aa3-1f51-47a1-b101-14887c6181d6.png">
