### PR TITLE
fix: ignore existing metadata when referencing registered schema

### DIFF
--- a/spec/medatada-overrides.spec.ts
+++ b/spec/medatada-overrides.spec.ts
@@ -110,4 +110,36 @@ describe('metadata overrides', () => {
       },
     });
   });
+
+  it('does not add object calculated overrides if type is provided in .openapi', () => {
+    const StringSchema = z.string().openapi({
+      refId: 'String',
+      example: 'existing field',
+    });
+
+    const TestSchema = z
+      .object({
+        key: StringSchema.nullable().openapi({ type: 'boolean' }),
+      })
+      .openapi({ refId: 'Test' });
+
+    expectSchema([StringSchema, TestSchema], {
+      String: {
+        example: 'existing field',
+        type: 'string',
+      },
+      Test: {
+        type: 'object',
+        properties: {
+          key: {
+            allOf: [
+              { $ref: '#/components/schemas/String' },
+              { type: 'boolean' },
+            ],
+          },
+        },
+        required: ['key'],
+      },
+    });
+  });
 });

--- a/spec/medatada-overrides.spec.ts
+++ b/spec/medatada-overrides.spec.ts
@@ -41,7 +41,9 @@ describe('metadata overrides', () => {
   });
 
   it('supports .openapi for registered schemas', () => {
-    const StringSchema = z.string().openapi({ refId: 'String' });
+    const StringSchema = z
+      .string()
+      .openapi({ refId: 'String', description: 'test' });
 
     const TestSchema = z
       .object({
@@ -51,6 +53,7 @@ describe('metadata overrides', () => {
 
     expectSchema([StringSchema, TestSchema], {
       String: {
+        description: 'test',
         type: 'string',
       },
       Test: {

--- a/spec/medatada-overrides.spec.ts
+++ b/spec/medatada-overrides.spec.ts
@@ -43,7 +43,7 @@ describe('metadata overrides', () => {
   it('supports .openapi for registered schemas', () => {
     const StringSchema = z
       .string()
-      .openapi({ refId: 'String', description: 'test' });
+      .openapi({ refId: 'String', description: 'test', example: "a" });
 
     const TestSchema = z
       .object({
@@ -54,6 +54,7 @@ describe('metadata overrides', () => {
     expectSchema([StringSchema, TestSchema], {
       String: {
         description: 'test',
+        example: 'a',
         type: 'string',
       },
       Test: {

--- a/spec/medatada-overrides.spec.ts
+++ b/spec/medatada-overrides.spec.ts
@@ -43,7 +43,7 @@ describe('metadata overrides', () => {
   it('supports .openapi for registered schemas', () => {
     const StringSchema = z
       .string()
-      .openapi({ refId: 'String', description: 'test', example: "a" });
+      .openapi({ refId: 'String', description: 'test', example: 'a' });
 
     const TestSchema = z
       .object({

--- a/spec/medatada-overrides.spec.ts
+++ b/spec/medatada-overrides.spec.ts
@@ -111,7 +111,7 @@ describe('metadata overrides', () => {
     });
   });
 
-  it('does not add object calculated overrides if type is provided in .openapi', () => {
+  it('does not add schema calculated overrides if type is provided in .openapi', () => {
     const StringSchema = z.string().openapi({
       refId: 'String',
       example: 'existing field',

--- a/spec/modifiers/nullable.spec.ts
+++ b/spec/modifiers/nullable.spec.ts
@@ -33,4 +33,26 @@ describe('nullable', () => {
       },
     });
   });
+
+  it('should not apply nullable if the schema is already nullable', () => {
+    const StringSchema = z.string().nullable().openapi({ refId: 'String' });
+
+    const TestSchema = z
+      .object({ key: StringSchema.nullable() })
+      .openapi({ refId: 'Test' });
+
+    expectSchema([StringSchema, TestSchema], {
+      String: {
+        type: 'string',
+        nullable: true,
+      },
+      Test: {
+        type: 'object',
+        properties: {
+          key: { $ref: '#/components/schemas/String' },
+        },
+        required: ['key'],
+      },
+    });
+  });
 });

--- a/src/lib/lodash.ts
+++ b/src/lib/lodash.ts
@@ -39,11 +39,11 @@ export function omit<
 export function omitBy<
   T extends object,
   Result = Partial<{ [K in keyof T]: T[keyof T] }>
->(object: T, predicate: (val: T[keyof T]) => boolean): Result {
+>(object: T, predicate: (val: T[keyof T], key: keyof T) => boolean): Result {
   const result: any = {};
 
   Object.entries(object).forEach(([key, value]) => {
-    if (!predicate(value)) {
+    if (!predicate(value, key as keyof T)) {
       result[key] = value;
     }
   });

--- a/src/openapi-generator.ts
+++ b/src/openapi-generator.ts
@@ -363,18 +363,22 @@ export class OpenAPIGenerator {
         $ref: `#/components/schemas/${refId}`,
       };
 
-      const nullableMetadata =
-        !schemaRef['nullable'] && zodSchema.isNullable()
-          ? { nullable: true }
-          : {};
-
-      const matchingValueKeys = Object.keys(metadata).filter(key =>
-        objectEquals(metadata[key], schemaRef[key])
+      // New metadata from ZodObject properties.
+      const newSchemaMetadata = omitBy(
+        this.toOpenAPISchema(innerSchema, zodSchema.isNullable()),
+        (value, key) =>
+          value === undefined || objectEquals(value, schemaRef[key])
       );
-      const newMetadata = omit(metadata, matchingValueKeys);
+
+      // New metadata from .openapi()
+      const newMetadata = omitBy(
+        metadata,
+        (value, key) =>
+          value === undefined || objectEquals(value, schemaRef[key])
+      );
 
       const appliedMetadata = this.applySchemaMetadata(
-        nullableMetadata,
+        newSchemaMetadata,
         newMetadata
       );
 

--- a/src/openapi-generator.ts
+++ b/src/openapi-generator.ts
@@ -363,7 +363,7 @@ export class OpenAPIGenerator {
         $ref: `#/components/schemas/${refId}`,
       };
 
-      // New metadata from ZodObject properties.
+      // New metadata from ZodSchema properties.
       const newSchemaMetadata = omitBy(
         this.toOpenAPISchema(innerSchema, zodSchema.isNullable()),
         (value, key) =>

--- a/src/openapi-generator.ts
+++ b/src/openapi-generator.ts
@@ -363,19 +363,23 @@ export class OpenAPIGenerator {
         $ref: `#/components/schemas/${refId}`,
       };
 
-      // New metadata from ZodSchema properties.
-      const newSchemaMetadata = omitBy(
-        this.toOpenAPISchema(innerSchema, zodSchema.isNullable()),
-        (value, key) =>
-          value === undefined || objectEquals(value, schemaRef[key])
-      );
-
       // New metadata from .openapi()
       const newMetadata = omitBy(
         metadata,
         (value, key) =>
           value === undefined || objectEquals(value, schemaRef[key])
       );
+
+      // New metadata from ZodSchema properties.
+      // Do not calculate schema metadata overrides if type is provvided in .openapi
+      // https://github.com/asteasolutions/zod-to-openapi/pull/52/files/8ff707fe06e222bc573ed46cf654af8ee0b0786d#r996430801
+      const newSchemaMetadata = !newMetadata.type
+        ? omitBy(
+            this.toOpenAPISchema(innerSchema, zodSchema.isNullable()),
+            (value, key) =>
+              value === undefined || objectEquals(value, schemaRef[key])
+          )
+        : {};
 
       const appliedMetadata = this.applySchemaMetadata(
         newSchemaMetadata,

--- a/src/openapi-generator.ts
+++ b/src/openapi-generator.ts
@@ -368,8 +368,8 @@ export class OpenAPIGenerator {
           ? { nullable: true }
           : {};
 
-      const matchingValueKeys = Object.keys(metadata).filter(
-        key => metadata[key] === schemaRef[key]
+      const matchingValueKeys = Object.keys(metadata).filter(key =>
+        objectEquals(metadata[key], schemaRef[key])
       );
       const newMetadata = omit(metadata, matchingValueKeys);
 


### PR DESCRIPTION
I currently have a small issue where existing metadata on a registered schema gets duplicated when it is referenced. This resolves that issue. In my example budget already contains that description and I never declared it again


Before/After:
<img width="1167" alt="image" src="https://user-images.githubusercontent.com/18017094/195990423-aea0d22b-2d7d-46f7-ad32-f3fe339efe8a.png">

