### PR TITLE
Fix `required` logic for parameters

### DIFF
--- a/spec/routes.spec.ts
+++ b/spec/routes.spec.ts
@@ -277,6 +277,25 @@ const routeTests = ({
       ]);
     });
 
+    it('generates required based on inner schema', () => {
+      const routeParameters = generateParamsForRoute({
+        request: {
+          query: z.object({ test: z.string().optional().default('test') }),
+        },
+      });
+
+      expect(routeParameters).toEqual([
+        {
+          in: 'query',
+          name: 'test',
+          required: false,
+          schema: {
+            type: 'string',
+          },
+        },
+      ]);
+    });
+
     describe('errors', () => {
       it('throws an error in case of names mismatch', () => {
         expect(() =>

--- a/src/openapi-generator.ts
+++ b/src/openapi-generator.ts
@@ -333,7 +333,8 @@ export class OpenAPIGenerator {
       });
     }
 
-    const required = !zodSchema.isOptional() && !zodSchema.isNullable();
+    const required =
+      !this.isOptionalSchema(zodSchema) && !zodSchema.isNullable();
 
     const schema = this.generateSimpleSchema(zodSchema);
 


### PR DESCRIPTION
Use the existing `isOptionalSchema` function to calculate if path parameters are optional.