### PR TITLE
Open API 3.1.0 Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,29 +138,38 @@ const registry = new OpenAPIRegistry();
 
 // Register definitions here
 
-const generator = new OpenAPIGenerator(registry.definitions);
+const generator = new OpenAPIGenerator(registry.definitions, '3.0.0');
 
 return generator.generateComponents();
 ```
 
 ### The Generator
 
-`generateComponents` will generate only the `/components` section of an OpenAPI document (e.g. only `schemas` and `parameters`), not generating actual routes.
-`generateDocument` will generate the entire document.
+The generator constructor takes 2 arguments. An array of definitions from the registry and an Open API version.
 
-You can set the override the version of Open API schema to generate (defaults to `3.0.0`) by setting it in the constructor or by manually overriding it using the `openapi` key for both the `generateComponents` and `generateDocument` functions.
+The Open API version affects how some components are generated. For example: changing the version to `3.1.0` from `3.0.0` will result in following differences:
 
 ```ts
-const generator = new OpenAPIGenerator(registry.definitions, '3.0.1');
-
-const components = generator.generateComponents({ openapi: '3.0.3' });
-const document = generator.generateDocument({
-  openapi: '3.1.0'
-  info: {
-    title: 'My API',
-  }
-});
+z.string().nullable().openapi(refId: 'name');
 ```
+
+```yml
+# 3.1.0
+# nullable is invalid in 3.1.0 but type arrays are invalid in previous versions
+name:
+  type:
+    - 'string'
+    - 'null'
+
+# 3.0.0
+name:
+  type: 'string'
+  nullable: true
+```
+
+`generateComponents` will generate only the `/components` section of an OpenAPI document (e.g. only `schemas` and `parameters`), not generating actual routes.
+
+`generateDocument` will generate the whole OpenAPI document.
 
 ### Defining schemas
 

--- a/README.md
+++ b/README.md
@@ -145,6 +145,14 @@ return generator.generateComponents();
 
 `generateComponents` will generate only the `/components` section of an OpenAPI document (e.g. only `schemas` and `parameters`), not generating actual routes.
 
+You can set the override the version of Open API schema to generate (defaults to `3.0.0`) by setting it in the constructor or by manually overriding it using the `openapi` key for both the `generateComponents` and `generateDocument` functions.
+
+```ts
+const generator = new OpenAPIGenerator(registry.definitions, '3.0.1');
+
+return generator.generateComponents({ openapi: '3.0.3' });
+```
+
 ### Defining schemas
 
 An OpenAPI schema should be registered using the `register` method of an `OpenAPIRegistry` instance.
@@ -317,7 +325,7 @@ A full OpenAPI document can be generated using the `generateDocument` method of 
 
 ```ts
 return generator.generateDocument({
-  openapi: '3.0.0',
+  openapi: '3.0.0', // By default the version passed into the generator's constructor is used but you can override it here
   info: {
     version: '1.0.0',
     title: 'My API',

--- a/README.md
+++ b/README.md
@@ -143,14 +143,23 @@ const generator = new OpenAPIGenerator(registry.definitions);
 return generator.generateComponents();
 ```
 
+### The Generator
+
 `generateComponents` will generate only the `/components` section of an OpenAPI document (e.g. only `schemas` and `parameters`), not generating actual routes.
+`generateDocument` will generate the entire document.
 
 You can set the override the version of Open API schema to generate (defaults to `3.0.0`) by setting it in the constructor or by manually overriding it using the `openapi` key for both the `generateComponents` and `generateDocument` functions.
 
 ```ts
 const generator = new OpenAPIGenerator(registry.definitions, '3.0.1');
 
-return generator.generateComponents({ openapi: '3.0.3' });
+const components = generator.generateComponents({ openapi: '3.0.3' });
+const document = generator.generateDocument({
+  openapi: '3.1.0'
+  info: {
+    title: 'My API',
+  }
+});
 ```
 
 ### Defining schemas
@@ -325,7 +334,6 @@ A full OpenAPI document can be generated using the `generateDocument` method of 
 
 ```ts
 return generator.generateDocument({
-  openapi: '3.0.0', // By default the version passed into the generator's constructor is used but you can override it here
   info: {
     version: '1.0.0',
     title: 'My API',

--- a/example/index.ts
+++ b/example/index.ts
@@ -67,10 +67,9 @@ registry.registerPath({
 });
 
 function getOpenApiDocumentation() {
-  const generator = new OpenAPIGenerator(registry.definitions);
+  const generator = new OpenAPIGenerator(registry.definitions, '3.0.0');
 
   return generator.generateDocument({
-    openapi: '3.0.0',
     info: {
       version: '1.0.0',
       title: 'My API',

--- a/spec/custom-components.spec.ts
+++ b/spec/custom-components.spec.ts
@@ -53,7 +53,7 @@ describe('Custom components', () => {
       },
     });
 
-    const builder = new OpenAPIGenerator(registry.definitions, '3.0.0');
+    const builder = new OpenAPIGenerator(registry.definitions);
     const document = builder.generateDocument(testDocConfig);
 
     expect(document.paths['/units'].get.security).toEqual([{ bearerAuth: [] }]);
@@ -92,7 +92,7 @@ describe('Custom components', () => {
       },
     });
 
-    const builder = new OpenAPIGenerator(registry.definitions, '3.0.0');
+    const builder = new OpenAPIGenerator(registry.definitions);
     const document = builder.generateDocument(testDocConfig);
 
     expect(document.paths['/units'].get.responses['200'].headers).toEqual({

--- a/spec/custom-components.spec.ts
+++ b/spec/custom-components.spec.ts
@@ -53,7 +53,7 @@ describe('Custom components', () => {
       },
     });
 
-    const builder = new OpenAPIGenerator(registry.definitions);
+    const builder = new OpenAPIGenerator(registry.definitions, '3.0.0');
     const document = builder.generateDocument(testDocConfig);
 
     expect(document.paths['/units'].get.security).toEqual([{ bearerAuth: [] }]);
@@ -92,7 +92,7 @@ describe('Custom components', () => {
       },
     });
 
-    const builder = new OpenAPIGenerator(registry.definitions);
+    const builder = new OpenAPIGenerator(registry.definitions, '3.0.0');
     const document = builder.generateDocument(testDocConfig);
 
     expect(document.paths['/units'].get.responses['200'].headers).toEqual({

--- a/spec/custom-components.spec.ts
+++ b/spec/custom-components.spec.ts
@@ -1,11 +1,14 @@
-import { OpenAPIGenerator } from '../src/openapi-generator';
+import {
+  OpenAPIGenerator,
+  OpenAPIObjectConfig,
+} from '../src/openapi-generator';
 import { OpenAPIRegistry } from '../src/openapi-registry';
 import { z } from 'zod';
 import { extendZodWithOpenApi } from '../src/zod-extensions';
 
 extendZodWithOpenApi(z);
 
-const testDocConfig = {
+const testDocConfig: OpenAPIObjectConfig = {
   openapi: '3.0.0',
   info: {
     version: '1.0.0',

--- a/spec/custom-components.spec.ts
+++ b/spec/custom-components.spec.ts
@@ -9,7 +9,6 @@ import { extendZodWithOpenApi } from '../src/zod-extensions';
 extendZodWithOpenApi(z);
 
 const testDocConfig: OpenAPIObjectConfig = {
-  openapi: '3.0.0',
   info: {
     version: '1.0.0',
     title: 'Swagger Petstore',
@@ -53,7 +52,7 @@ describe('Custom components', () => {
       },
     });
 
-    const builder = new OpenAPIGenerator(registry.definitions);
+    const builder = new OpenAPIGenerator(registry.definitions, '3.0.0');
     const document = builder.generateDocument(testDocConfig);
 
     expect(document.paths['/units'].get.security).toEqual([{ bearerAuth: [] }]);
@@ -92,7 +91,7 @@ describe('Custom components', () => {
       },
     });
 
-    const builder = new OpenAPIGenerator(registry.definitions);
+    const builder = new OpenAPIGenerator(registry.definitions, '3.0.0');
     const document = builder.generateDocument(testDocConfig);
 
     expect(document.paths['/units'].get.responses['200'].headers).toEqual({

--- a/spec/lib/helpers.ts
+++ b/spec/lib/helpers.ts
@@ -1,19 +1,19 @@
-import { OpenAPIGenerator } from '../../src/openapi-generator';
+import { OpenAPIGenerator, OpenApiVersion } from '../../src/openapi-generator';
 import type { SchemasObject } from 'openapi3-ts';
 import type { ZodSchema } from 'zod';
 
 export function createSchemas(
   zodSchemas: ZodSchema<any>[],
-  openAPIVersion?: string
+  openapi: OpenApiVersion = '3.0.0'
 ) {
   const definitions = zodSchemas.map(schema => ({
     type: 'schema' as const,
     schema,
   }));
 
-  const { components } = new OpenAPIGenerator(definitions).generateComponents(
-    openAPIVersion
-  );
+  const { components } = new OpenAPIGenerator(definitions).generateComponents({
+    openapi,
+  });
 
   return components;
 }
@@ -21,9 +21,9 @@ export function createSchemas(
 export function expectSchema(
   zodSchemas: ZodSchema<any>[],
   openAPISchemas: SchemasObject,
-  openAPIVersion?: string
+  openapi: OpenApiVersion = '3.0.0'
 ) {
-  const components = createSchemas(zodSchemas, openAPIVersion);
+  const components = createSchemas(zodSchemas, openapi);
 
   expect(components?.['schemas']).toEqual(openAPISchemas);
 }

--- a/spec/lib/helpers.ts
+++ b/spec/lib/helpers.ts
@@ -2,22 +2,28 @@ import { OpenAPIGenerator } from '../../src/openapi-generator';
 import type { SchemasObject } from 'openapi3-ts';
 import type { ZodSchema } from 'zod';
 
-export function createSchemas(zodSchemas: ZodSchema<any>[]) {
+export function createSchemas(
+  zodSchemas: ZodSchema<any>[],
+  openAPIVersion?: string
+) {
   const definitions = zodSchemas.map(schema => ({
     type: 'schema' as const,
     schema,
   }));
 
-  const { components } = new OpenAPIGenerator(definitions).generateComponents();
+  const { components } = new OpenAPIGenerator(definitions).generateComponents(
+    openAPIVersion
+  );
 
   return components;
 }
 
 export function expectSchema(
   zodSchemas: ZodSchema<any>[],
-  openAPISchemas: SchemasObject
+  openAPISchemas: SchemasObject,
+  openAPIVersion?: string
 ) {
-  const components = createSchemas(zodSchemas);
+  const components = createSchemas(zodSchemas, openAPIVersion);
 
   expect(components?.['schemas']).toEqual(openAPISchemas);
 }

--- a/spec/lib/helpers.ts
+++ b/spec/lib/helpers.ts
@@ -4,16 +4,17 @@ import type { ZodSchema } from 'zod';
 
 export function createSchemas(
   zodSchemas: ZodSchema<any>[],
-  openapi: OpenApiVersion = '3.0.0'
+  openApiVersion: OpenApiVersion = '3.0.0'
 ) {
   const definitions = zodSchemas.map(schema => ({
     type: 'schema' as const,
     schema,
   }));
 
-  const { components } = new OpenAPIGenerator(definitions).generateComponents({
-    openapi,
-  });
+  const { components } = new OpenAPIGenerator(
+    definitions,
+    openApiVersion
+  ).generateComponents();
 
   return components;
 }
@@ -21,9 +22,9 @@ export function createSchemas(
 export function expectSchema(
   zodSchemas: ZodSchema<any>[],
   openAPISchemas: SchemasObject,
-  openapi: OpenApiVersion = '3.0.0'
+  openApiVersion: OpenApiVersion = '3.0.0'
 ) {
-  const components = createSchemas(zodSchemas, openapi);
+  const components = createSchemas(zodSchemas, openApiVersion);
 
   expect(components?.['schemas']).toEqual(openAPISchemas);
 }

--- a/spec/modifiers/nullable.spec.ts
+++ b/spec/modifiers/nullable.spec.ts
@@ -55,4 +55,69 @@ describe('nullable', () => {
       },
     });
   });
+
+  it('supports nullable in open api 3.1.0', () => {
+    expectSchema(
+      [z.string().nullable().openapi({ refId: 'NullableString' })],
+      {
+        NullableString: { type: ['string', 'null'] },
+      },
+      '3.1.0'
+    );
+  });
+
+  it('supports nullable for registered schemas in open api 3.1.0', () => {
+    const StringSchema = z.string().openapi({ refId: 'String' });
+
+    const TestSchema = z
+      .object({ key: StringSchema.nullable() })
+      .openapi({ refId: 'Test' });
+
+    expectSchema(
+      [StringSchema, TestSchema],
+      {
+        String: {
+          type: 'string',
+        },
+        Test: {
+          type: 'object',
+          properties: {
+            key: {
+              allOf: [
+                { $ref: '#/components/schemas/String' },
+                { type: ['string', 'null'] },
+              ],
+            },
+          },
+          required: ['key'],
+        },
+      },
+      '3.1.0'
+    );
+  });
+
+  it('should not apply nullable if the schema is already nullable in open api 3.1.0', () => {
+    const StringSchema = z.string().nullable().openapi({ refId: 'String' });
+
+    const TestSchema = z
+      .object({ key: StringSchema.nullable() })
+      .openapi({ refId: 'Test' });
+
+    expectSchema(
+      [StringSchema, TestSchema],
+      {
+        String: {
+          type: ['string', 'null'],
+        },
+        Test: {
+          type: 'object',
+          properties: {
+            key: { $ref: '#/components/schemas/String' },
+          },
+          required: ['key'],
+        },
+      },
+      '3.1.0'
+    );
+  });
 });

--- a/spec/routes.spec.ts
+++ b/spec/routes.spec.ts
@@ -70,8 +70,7 @@ const routeTests = ({
       });
 
       const document = new OpenAPIGenerator(
-        registry.definitions,
-        '3.0.0'
+        registry.definitions
       ).generateDocument(testDocConfig);
       const responses = document[rootDocPath]?.['/'].get.responses;
 
@@ -112,8 +111,7 @@ const routeTests = ({
       });
 
       const document = new OpenAPIGenerator(
-        registry.definitions,
-        '3.0.0'
+        registry.definitions
       ).generateDocument(testDocConfig);
       const responses = document[rootDocPath]?.['/'].get.responses;
 
@@ -153,8 +151,7 @@ const routeTests = ({
       });
 
       const document = new OpenAPIGenerator(
-        registry.definitions,
-        '3.0.0'
+        registry.definitions
       ).generateDocument(testDocConfig);
       const responses = document[rootDocPath]?.['/'].get.responses;
 
@@ -181,8 +178,7 @@ const routeTests = ({
       });
 
       const document = new OpenAPIGenerator(
-        registry.definitions,
-        '3.0.0'
+        registry.definitions
       ).generateDocument(testDocConfig);
       const responses = document[rootDocPath]?.['/'].get.responses;
 
@@ -396,10 +392,10 @@ const routeTests = ({
         route,
       };
 
-      const { paths } = new OpenAPIGenerator(
-        [...paramDefinitions, routeDefinition],
-        '3.0.0'
-      ).generateDocument(testDocConfig);
+      const { paths } = new OpenAPIGenerator([
+        ...paramDefinitions,
+        routeDefinition,
+      ]).generateDocument(testDocConfig);
 
       const routes = paths[route.path] as PathItemObject;
 
@@ -430,8 +426,7 @@ const routeTests = ({
       registry[registerFunction](route);
 
       const document = new OpenAPIGenerator(
-        registry.definitions,
-        '3.0.0'
+        registry.definitions
       ).generateDocument(testDocConfig);
 
       const { requestBody } = document[rootDocPath]?.['/'].get;
@@ -467,8 +462,7 @@ const routeTests = ({
       registry[registerFunction](route);
 
       const document = new OpenAPIGenerator(
-        registry.definitions,
-        '3.0.0'
+        registry.definitions
       ).generateDocument(testDocConfig);
 
       const requestBody = document[rootDocPath]?.['/'].get.requestBody.content;
@@ -508,8 +502,7 @@ const routeTests = ({
       registry[registerFunction](route);
 
       const document = new OpenAPIGenerator(
-        registry.definitions,
-        '3.0.0'
+        registry.definitions
       ).generateDocument(testDocConfig);
 
       const requestBody = document[rootDocPath]?.['/'].get.requestBody.content;

--- a/spec/routes.spec.ts
+++ b/spec/routes.spec.ts
@@ -1,6 +1,9 @@
 import { z, ZodSchema } from 'zod';
 import { OperationObject, PathItemObject } from 'openapi3-ts';
-import { OpenAPIGenerator } from '../src/openapi-generator';
+import {
+  OpenAPIGenerator,
+  OpenAPIObjectConfig,
+} from '../src/openapi-generator';
 import { OpenAPIRegistry, RouteConfig } from '../src/openapi-registry';
 
 function createTestRoute(props: Partial<RouteConfig> = {}): RouteConfig {
@@ -16,7 +19,7 @@ function createTestRoute(props: Partial<RouteConfig> = {}): RouteConfig {
   };
 }
 
-const testDocConfig = {
+const testDocConfig: OpenAPIObjectConfig = {
   openapi: '3.0.0',
   info: {
     version: '1.0.0',

--- a/spec/routes.spec.ts
+++ b/spec/routes.spec.ts
@@ -20,7 +20,6 @@ function createTestRoute(props: Partial<RouteConfig> = {}): RouteConfig {
 }
 
 const testDocConfig: OpenAPIObjectConfig = {
-  openapi: '3.0.0',
   info: {
     version: '1.0.0',
     title: 'Swagger Petstore',
@@ -70,7 +69,8 @@ const routeTests = ({
       });
 
       const document = new OpenAPIGenerator(
-        registry.definitions
+        registry.definitions,
+        '3.0.0'
       ).generateDocument(testDocConfig);
       const responses = document[rootDocPath]?.['/'].get.responses;
 
@@ -111,7 +111,8 @@ const routeTests = ({
       });
 
       const document = new OpenAPIGenerator(
-        registry.definitions
+        registry.definitions,
+        '3.0.0'
       ).generateDocument(testDocConfig);
       const responses = document[rootDocPath]?.['/'].get.responses;
 
@@ -151,7 +152,8 @@ const routeTests = ({
       });
 
       const document = new OpenAPIGenerator(
-        registry.definitions
+        registry.definitions,
+        '3.0.0'
       ).generateDocument(testDocConfig);
       const responses = document[rootDocPath]?.['/'].get.responses;
 
@@ -178,7 +180,8 @@ const routeTests = ({
       });
 
       const document = new OpenAPIGenerator(
-        registry.definitions
+        registry.definitions,
+        '3.0.0'
       ).generateDocument(testDocConfig);
       const responses = document[rootDocPath]?.['/'].get.responses;
 
@@ -392,10 +395,10 @@ const routeTests = ({
         route,
       };
 
-      const { paths } = new OpenAPIGenerator([
-        ...paramDefinitions,
-        routeDefinition,
-      ]).generateDocument(testDocConfig);
+      const { paths } = new OpenAPIGenerator(
+        [...paramDefinitions, routeDefinition],
+        '3.0.0'
+      ).generateDocument(testDocConfig);
 
       const routes = paths[route.path] as PathItemObject;
 
@@ -426,7 +429,8 @@ const routeTests = ({
       registry[registerFunction](route);
 
       const document = new OpenAPIGenerator(
-        registry.definitions
+        registry.definitions,
+        '3.0.0'
       ).generateDocument(testDocConfig);
 
       const { requestBody } = document[rootDocPath]?.['/'].get;
@@ -462,7 +466,8 @@ const routeTests = ({
       registry[registerFunction](route);
 
       const document = new OpenAPIGenerator(
-        registry.definitions
+        registry.definitions,
+        '3.0.0'
       ).generateDocument(testDocConfig);
 
       const requestBody = document[rootDocPath]?.['/'].get.requestBody.content;
@@ -502,7 +507,8 @@ const routeTests = ({
       registry[registerFunction](route);
 
       const document = new OpenAPIGenerator(
-        registry.definitions
+        registry.definitions,
+        '3.0.0'
       ).generateDocument(testDocConfig);
 
       const requestBody = document[rootDocPath]?.['/'].get.requestBody.content;

--- a/spec/routes.spec.ts
+++ b/spec/routes.spec.ts
@@ -70,7 +70,8 @@ const routeTests = ({
       });
 
       const document = new OpenAPIGenerator(
-        registry.definitions
+        registry.definitions,
+        '3.0.0'
       ).generateDocument(testDocConfig);
       const responses = document[rootDocPath]?.['/'].get.responses;
 
@@ -111,7 +112,8 @@ const routeTests = ({
       });
 
       const document = new OpenAPIGenerator(
-        registry.definitions
+        registry.definitions,
+        '3.0.0'
       ).generateDocument(testDocConfig);
       const responses = document[rootDocPath]?.['/'].get.responses;
 
@@ -151,7 +153,8 @@ const routeTests = ({
       });
 
       const document = new OpenAPIGenerator(
-        registry.definitions
+        registry.definitions,
+        '3.0.0'
       ).generateDocument(testDocConfig);
       const responses = document[rootDocPath]?.['/'].get.responses;
 
@@ -178,7 +181,8 @@ const routeTests = ({
       });
 
       const document = new OpenAPIGenerator(
-        registry.definitions
+        registry.definitions,
+        '3.0.0'
       ).generateDocument(testDocConfig);
       const responses = document[rootDocPath]?.['/'].get.responses;
 
@@ -392,10 +396,10 @@ const routeTests = ({
         route,
       };
 
-      const { paths } = new OpenAPIGenerator([
-        ...paramDefinitions,
-        routeDefinition,
-      ]).generateDocument(testDocConfig);
+      const { paths } = new OpenAPIGenerator(
+        [...paramDefinitions, routeDefinition],
+        '3.0.0'
+      ).generateDocument(testDocConfig);
 
       const routes = paths[route.path] as PathItemObject;
 
@@ -426,7 +430,8 @@ const routeTests = ({
       registry[registerFunction](route);
 
       const document = new OpenAPIGenerator(
-        registry.definitions
+        registry.definitions,
+        '3.0.0'
       ).generateDocument(testDocConfig);
 
       const { requestBody } = document[rootDocPath]?.['/'].get;
@@ -462,7 +467,8 @@ const routeTests = ({
       registry[registerFunction](route);
 
       const document = new OpenAPIGenerator(
-        registry.definitions
+        registry.definitions,
+        '3.0.0'
       ).generateDocument(testDocConfig);
 
       const requestBody = document[rootDocPath]?.['/'].get.requestBody.content;
@@ -502,7 +508,8 @@ const routeTests = ({
       registry[registerFunction](route);
 
       const document = new OpenAPIGenerator(
-        registry.definitions
+        registry.definitions,
+        '3.0.0'
       ).generateDocument(testDocConfig);
 
       const requestBody = document[rootDocPath]?.['/'].get.requestBody.content;

--- a/spec/types/discriminated-union.spec.ts
+++ b/spec/types/discriminated-union.spec.ts
@@ -81,6 +81,51 @@ describe('discriminated union', () => {
     );
   });
 
+  it('does not create a discriminator mapping when the discrimnated union is nullable', () => {
+    const Text = z
+      .object({ type: z.literal('text'), text: z.string() })
+      .openapi({ refId: 'obj1' });
+    const Image = z
+      .object({ type: z.literal('image'), src: z.string() })
+      .openapi({ refId: 'obj2' });
+
+    expectSchema(
+      [
+        Text,
+        Image,
+        z
+          .discriminatedUnion('type', [Text, Image])
+          .nullable()
+          .openapi({ refId: 'Test' }),
+      ],
+      {
+        Test: {
+          oneOf: [
+            { $ref: '#/components/schemas/obj1' },
+            { $ref: '#/components/schemas/obj2' },
+            { nullable: true },
+          ],
+        },
+        obj1: {
+          type: 'object',
+          required: ['type', 'text'],
+          properties: {
+            type: { type: 'string', enum: ['text'] },
+            text: { type: 'string' },
+          },
+        },
+        obj2: {
+          type: 'object',
+          required: ['type', 'src'],
+          properties: {
+            type: { type: 'string', enum: ['image'] },
+            src: { type: 'string' },
+          },
+        },
+      }
+    );
+  });
+
   it('does not create a discriminator mapping when only some objects in the discriminated union contain a registered schema', () => {
     const Text = z
       .object({ type: z.literal('text'), text: z.string() })

--- a/spec/types/intersection.spec.ts
+++ b/spec/types/intersection.spec.ts
@@ -31,4 +31,39 @@ describe('intersection', () => {
       }
     );
   });
+
+  it('supports nullable intersection types', () => {
+    const Person = z.object({
+      name: z.string(),
+    });
+
+    const Employee = z.object({
+      role: z.string(),
+    });
+
+    expectSchema(
+      [z.intersection(Person, Employee).nullable().openapi({ refId: 'Test' })],
+      {
+        Test: {
+          anyOf: [
+            {
+              allOf: [
+                {
+                  type: 'object',
+                  properties: { name: { type: 'string' } },
+                  required: ['name'],
+                },
+                {
+                  type: 'object',
+                  properties: { role: { type: 'string' } },
+                  required: ['role'],
+                },
+              ],
+            },
+            { nullable: true },
+          ],
+        },
+      }
+    );
+  });
 });

--- a/spec/types/union.spec.ts
+++ b/spec/types/union.spec.ts
@@ -39,4 +39,16 @@ describe('union', () => {
       }
     );
   });
+
+  it('supports nullable union types in 3.1.0', () => {
+    expectSchema(
+      [z.string().or(z.number()).nullable().openapi({ refId: 'Test' })],
+      {
+        Test: {
+          anyOf: [{ type: 'string' }, { type: 'number' }, { type: 'null' }],
+        },
+      },
+      '3.1.0'
+    );
+  });
 });

--- a/spec/types/union.spec.ts
+++ b/spec/types/union.spec.ts
@@ -28,4 +28,15 @@ describe('union', () => {
       }
     );
   });
+
+  it('supports nullable union types', () => {
+    expectSchema(
+      [z.string().or(z.number()).nullable().openapi({ refId: 'Test' })],
+      {
+        Test: {
+          anyOf: [{ type: 'string' }, { type: 'number' }, { nullable: true }],
+        },
+      }
+    );
+  });
 });

--- a/src/openapi-generator.ts
+++ b/src/openapi-generator.ts
@@ -61,7 +61,7 @@ export type OpenApiVersion = typeof openApiVersions[number];
 // Omit does not work, since OpenAPIObject extends ISpecificationExtension
 // and is inferred as { [key: number]: any; [key: string]: any }
 export interface OpenAPIObjectConfig {
-  openapi: OpenApiVersion;
+  openapi?: OpenApiVersion;
   info: InfoObject;
   servers?: ServerObject[];
   security?: SecurityRequirementObject[];
@@ -87,18 +87,23 @@ export class OpenAPIGenerator {
     name: string;
     component: OpenAPIComponentObject;
   }[] = [];
-  private openAPIVersion: OpenApiVersion = '3.0.0';
 
-  constructor(private definitions: OpenAPIDefinitions[]) {
+  constructor(
+    private definitions: OpenAPIDefinitions[],
+    private openAPIVersion: OpenApiVersion
+  ) {
     this.sortDefinitions();
   }
 
   generateDocument(config: OpenAPIObjectConfig): OpenAPIObject {
-    this.openAPIVersion = config.openapi;
+    if (config.openapi) {
+      this.openAPIVersion = config.openapi;
+    }
     this.definitions.forEach(definition => this.generateSingle(definition));
 
     return {
       ...config,
+      openapi: this.openAPIVersion,
       components: this.buildComponents(),
       paths: this.pathRefs,
       // As the `webhooks` key is invalid in Open API 3.0.x we need to optionally set it
@@ -111,7 +116,9 @@ export class OpenAPIGenerator {
   generateComponents(
     config?: Pick<OpenAPIObjectConfig, 'openapi'>
   ): Pick<OpenAPIObject, 'components'> {
-    this.openAPIVersion = config?.openapi ?? this.openAPIVersion;
+    if (config?.openapi) {
+      this.openAPIVersion = config.openapi;
+    }
 
     this.definitions.forEach(definition => this.generateSingle(definition));
 

--- a/src/openapi-generator.ts
+++ b/src/openapi-generator.ts
@@ -816,12 +816,7 @@ export class OpenAPIGenerator {
 
       if (isNullable) {
         return {
-          anyOf: [
-            allOfSchema,
-            ...(isNullable
-              ? [this.mapNullableType(undefined, isNullable)]
-              : []),
-          ],
+          anyOf: [allOfSchema, this.mapNullableType(undefined, isNullable)],
         };
       }
 

--- a/src/openapi-generator.ts
+++ b/src/openapi-generator.ts
@@ -90,7 +90,7 @@ export class OpenAPIGenerator {
   }
 
   generateDocument(config: OpenAPIObjectConfig): OpenAPIObject {
-    this.openAPIVersion = config.openapi; // Preference the constructor version over this one
+    this.openAPIVersion = config.openapi;
     this.definitions.forEach(definition => this.generateSingle(definition));
 
     return {

--- a/src/openapi-generator.ts
+++ b/src/openapi-generator.ts
@@ -811,7 +811,7 @@ export class OpenAPIGenerator {
       const subtypes = this.flattenIntersectionTypes(zodSchema);
 
       const allOfSchema: SchemaObject = {
-        allOf: [...subtypes.map(schema => this.generateInnerSchema(schema))],
+        allOf: subtypes.map(schema => this.generateInnerSchema(schema)),
       };
 
       if (isNullable) {

--- a/src/openapi-generator.ts
+++ b/src/openapi-generator.ts
@@ -90,7 +90,7 @@ export class OpenAPIGenerator {
 
   constructor(
     private definitions: OpenAPIDefinitions[],
-    private openAPIVersion: OpenApiVersion
+    private openAPIVersion: OpenApiVersion = '3.0.0'
   ) {
     this.sortDefinitions();
   }


### PR DESCRIPTION
# BREAKING CHANGE

The generator's constructor now takes a mandatory Open API version. This is required in order to drive different generation behaviour based on the version.

`generateDocument` no longer takes a `openapi` version and instead we will use the version from the generator's constructor to populate this field.

## Why we need this change

Open API 3.1.0 made `nullable` an invalid key and instead chose to become JSON Schema compatible by using a type array with `null` inside it. The problem here is that the `type` array is invalid in previous versions.

https://www.openapis.org/blog/2021/02/16/migrating-from-openapi-3-0-to-3-1-0

<img width="1062" alt="image" src="https://user-images.githubusercontent.com/18017094/196689432-5e702ff8-9c50-4e33-9eda-b3dd894d9b09.png">

## Other Changes

Also adds nullable support for:
- Union
- Discriminated Union
- Intersection
- Array
- Record
