### PR TITLE
supports minLength/maxLength on string type

### DIFF
--- a/spec/types/string.spec.ts
+++ b/spec/types/string.spec.ts
@@ -8,6 +8,15 @@ describe('string', () => {
     });
   });
 
+  it('supports minLength / maxLength on string', () => {
+    expectSchema(
+      [z.string().min(5).max(10).openapi({ refId: 'minMaxLengthString' })],
+      {
+        minMaxLengthString: { type: 'string', minLength: 5, maxLength: 10 },
+      }
+    );
+  });
+
   it('supports string literals', () => {
     expectSchema([z.literal('John Doe').openapi({ refId: 'Literal' })], {
       Literal: { type: 'string', enum: ['John Doe'] },

--- a/src/openapi-generator.ts
+++ b/src/openapi-generator.ts
@@ -632,6 +632,13 @@ export class OpenAPIGenerator {
       const regexCheck = this.getZodStringCheck(zodSchema, 'regex');
       return {
         type: 'string',
+        // FIXME: https://github.com/colinhacks/zod/commit/d78047e9f44596a96d637abb0ce209cd2732d88c
+        minLength: Number.isFinite(zodSchema.minLength)
+          ? zodSchema.minLength ?? undefined
+          : undefined,
+        maxLength: Number.isFinite(zodSchema.maxLength)
+          ? zodSchema.maxLength ?? undefined
+          : undefined,
         nullable: isNullable ? true : undefined,
         format: this.mapStringFormat(zodSchema),
         pattern: regexCheck?.regex.source,


### PR DESCRIPTION
**Note:** 
Number.isFinite" is used because "zod v3.19.1" has not yet been applied to "zod-to-openapi".

See below for details.
https://github.com/colinhacks/zod/commit/d78047e9f44596a96d637abb0ce209cd2732d88c