### PR TITLE
Fix Route types to support strict objects

### DIFF
--- a/spec/routes.spec.ts
+++ b/spec/routes.spec.ts
@@ -302,6 +302,28 @@ const routeTests = ({
       ]);
     });
 
+    it('supports strict zod objects', () => {
+      const routeParameters = generateParamsForRoute({
+        request: {
+          query: z.strictObject({
+            test: z.string().optional().default('test'),
+          }),
+        },
+      });
+
+      expect(routeParameters).toEqual([
+        {
+          in: 'query',
+          name: 'test',
+          required: false,
+          schema: {
+            type: 'string',
+            default: 'test',
+          },
+        },
+      ]);
+    });
+
     describe('errors', () => {
       it('throws an error in case of names mismatch', () => {
         expect(() =>

--- a/src/lib/zod-is-type.ts
+++ b/src/lib/zod-is-type.ts
@@ -12,7 +12,7 @@ type ZodTypes = {
   ZodNull: z.ZodNull;
   ZodNullable: z.ZodNullable<any>;
   ZodNumber: z.ZodNumber;
-  ZodObject: z.ZodObject<any>;
+  ZodObject: z.AnyZodObject;
   ZodOptional: z.ZodOptional<any>;
   ZodRecord: z.ZodRecord;
   ZodSchema: z.ZodSchema;

--- a/src/openapi-generator.ts
+++ b/src/openapi-generator.ts
@@ -12,6 +12,7 @@ import {
   DiscriminatorObject,
 } from 'openapi3-ts';
 import type {
+  AnyZodObject,
   ZodObject,
   ZodRawShape,
   ZodSchema,
@@ -588,7 +589,7 @@ export class OpenAPIGenerator {
   }
 
   private mapDiscriminator(
-    zodObjects: ZodObject<any>[],
+    zodObjects: AnyZodObject[],
     discriminator: string
   ): DiscriminatorObject | undefined {
     // All schemas must be registered to use a discriminator

--- a/src/openapi-registry.ts
+++ b/src/openapi-registry.ts
@@ -17,7 +17,7 @@ import {
   SchemaObject,
   SecuritySchemeObject,
 } from 'openapi3-ts';
-import type { ZodObject, ZodSchema, ZodType } from 'zod';
+import type { AnyZodObject, ZodSchema, ZodType } from 'zod';
 
 type Method = 'get' | 'post' | 'put' | 'delete' | 'patch';
 
@@ -50,8 +50,8 @@ export interface RouteConfig extends OperationObject {
   path: string;
   request?: {
     body?: ZodRequestBody;
-    params?: ZodObject<any>;
-    query?: ZodObject<any>;
+    params?: AnyZodObject;
+    query?: AnyZodObject;
     headers?: ZodType<unknown>[];
   };
   responses: {


### PR DESCRIPTION
Currently the ZodObject<any> type defaults the second value to "strip" which means that "strict" types are not supported.

Substitute usage of `ZodObject<any>` with `AnyZodObject` type.