### PR TITLE
feat: Add strict object additionalProperties: false mapping

### DIFF
--- a/spec/types/object.spec.ts
+++ b/spec/types/object.spec.ts
@@ -55,4 +55,29 @@ describe('object', () => {
       },
     });
   });
+
+  it('supports strict objects', () => {
+    expectSchema(
+      [
+        registerSchema(
+          'StrictObject',
+          z.strictObject({
+            test: z.string(),
+          })
+        ),
+      ],
+      {
+        StrictObject: {
+          type: 'object',
+          required: ['test'],
+          additionalProperties: false,
+          properties: {
+            test: {
+              type: 'string',
+            },
+          },
+        },
+      }
+    );
+  });
 });

--- a/spec/types/object.spec.ts
+++ b/spec/types/object.spec.ts
@@ -56,7 +56,7 @@ describe('object', () => {
     });
   });
 
-  it('supports strict objects', () => {
+  it('maps additionalProperties to false for strict objects', () => {
     expectSchema(
       [
         registerSchema(

--- a/src/openapi-generator.ts
+++ b/src/openapi-generator.ts
@@ -896,14 +896,16 @@ export class OpenAPIGenerator {
     return undefined;
   }
 
-  private requiredKeysOf(objectSchema: ZodObject<ZodRawShape>) {
+  private requiredKeysOf(
+    objectSchema: ZodObject<ZodRawShape, UnknownKeysParam>
+  ) {
     return Object.entries(objectSchema._def.shape())
       .filter(([_key, type]) => !this.isOptionalSchema(type))
       .map(([key, _type]) => key);
   }
 
   private toOpenAPIObjectSchema(
-    zodSchema: ZodObject<ZodRawShape>,
+    zodSchema: ZodObject<ZodRawShape, UnknownKeysParam>,
     isNullable: boolean,
     defaultValue?: ZodRawShape
   ): SchemaObject {
@@ -935,7 +937,7 @@ export class OpenAPIGenerator {
       prop => !keysRequiredByParent.includes(prop)
     );
 
-    const unknownKeysOption = zodSchema._unknownKeys as UnknownKeysParam;
+    const unknownKeysOption = zodSchema._def.unknownKeys;
 
     const objectData = {
       ...this.mapNullableType('object', isNullable),
@@ -946,8 +948,8 @@ export class OpenAPIGenerator {
         ? { required: additionallyRequired }
         : {}),
 
-      ...(unknownKeysOption === 'passthrough'
-        ? { additionalProperties: true }
+      ...(unknownKeysOption === 'strict'
+        ? { additionalProperties: false }
         : {}),
     };
 


### PR DESCRIPTION
According to the [Open API Specification](https://swagger.io/specification/):

>additionalProperties - Value can be boolean or object. Inline or referenced schema MUST be of a [Schema Object](https://swagger.io/specification/#schema-object) and not a standard JSON Schema. Consistent with JSON Schema, additionalProperties **defaults to true**.

According to the [Zod Readme](https://github.com/colinhacks/zod#passthrough):

>.passthrough
**By default** Zod object schemas strip out unrecognized keys during parsing.

This means that we should see alot more of this in the schema if this bit of the code was working:

<img width="382" alt="image" src="https://user-images.githubusercontent.com/18017094/203039047-7d6de7d1-a8f5-4137-9ea7-e8ed74e0ab32.png">

Since this defaults to true we don't need this passthrough code. Instead I'll add the option to map strict objects.