### PR TITLE
Bump Zod Version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "zod": "^3.20.2"
       },
       "peerDependencies": {
-        "zod": "^3.14.0"
+        "zod": "^3.20.2"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "openapi3-ts": "^3.1.1"
   },
   "peerDependencies": {
-    "zod": "^3.14.0"
+    "zod": "^3.20.2"
   },
   "devDependencies": {
     "@types/jest": "^27.4.1",


### PR DESCRIPTION
Resolves #81

This is a *Breaking Change*.

Zod [introduced a breaking change](https://github.com/colinhacks/zod/pull/1290#issuecomment-1347912219) to their types in `3.20` which is incompatible with previous versions of this library. This bumps up the peerDependency version of Zod to `3.20.2`