### PR TITLE
For 'nativeEnum', should be 'type: integer', not 'type: number

### DIFF
--- a/spec/types/native-enum.spec.ts
+++ b/spec/types/native-enum.spec.ts
@@ -41,7 +41,7 @@ describe('native enum', () => {
 
     expectSchema([nativeEnumSchema], {
       NativeEnum: {
-        type: 'number',
+        type: 'integer',
         description: 'A native numbers enum in zod',
         enum: [1, 42, 3],
       },

--- a/src/openapi-generator.ts
+++ b/src/openapi-generator.ts
@@ -810,7 +810,7 @@ export class OpenAPIGenerator {
 
       return {
         ...this.mapNullableType(
-          type === 'numeric' ? 'number' : 'string',
+          type === 'numeric' ? 'integer' : 'string',
           isNullable
         ),
         enum: values,


### PR DESCRIPTION
For example, if I use 'openapi-generator for php' to automatically generate a .php file from 'openapi-docs.yml', the 'nativeEnum' part is converted to PHP's float type.
Normally, numeric Enums should be of type int, not float.