### PR TITLE
Add 'head', 'options', and 'trace' to Method type in OpenAPI registry

### DIFF
--- a/src/openapi-registry.ts
+++ b/src/openapi-registry.ts
@@ -19,7 +19,15 @@ import {
 } from 'openapi3-ts';
 import type { AnyZodObject, ZodSchema, ZodType } from 'zod';
 
-type Method = 'get' | 'post' | 'put' | 'delete' | 'patch' | 'head' | 'options' | 'trace';
+type Method =
+  | 'get'
+  | 'post'
+  | 'put'
+  | 'delete'
+  | 'patch'
+  | 'head'
+  | 'options'
+  | 'trace';
 
 export interface ZodMediaTypeObject {
   schema: ZodType<unknown> | SchemaObject | ReferenceObject;

--- a/src/openapi-registry.ts
+++ b/src/openapi-registry.ts
@@ -19,7 +19,7 @@ import {
 } from 'openapi3-ts';
 import type { AnyZodObject, ZodSchema, ZodType } from 'zod';
 
-type Method = 'get' | 'post' | 'put' | 'delete' | 'patch';
+type Method = 'get' | 'post' | 'put' | 'delete' | 'patch' | 'head' | 'options' | 'trace';
 
 export interface ZodMediaTypeObject {
   schema: ZodType<unknown> | SchemaObject | ReferenceObject;


### PR DESCRIPTION
Thank you for maintaining this excellent repository! I'm working on a project that uses the OPTIONS verb and needed to expand the list of available methods. Cheers.

`type Method = 'get' | 'post' | 'put' | 'delete' | 'patch' | 'head' | 'options' | 'trace';`