### PR TITLE
Export request types for composabilty

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,9 @@ export {
   OpenAPIRegistry,
   RouteConfig,
   ResponseConfig,
+  ZodMediaTypeObject,
+  ZodContentObject,
+  ZodRequestBody,
 } from './openapi-registry';
 
 export * as OpenAPI from 'openapi3-ts';


### PR DESCRIPTION
Wanting to compose parts of my API and zod schemas. To do this I would like to 'statically' define the request body and other metadata. Exposing these types will help. 