### PR TITLE
#115 added support for ZodPipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -404,6 +404,7 @@ The list of all supported types as of now is:
   - including `z.number().int()` being inferred as `type: 'integer'`
 - `ZodObject`
 - `ZodOptional`
+- `ZodPipeline`
 - `ZodRecord`
 - `ZodString`
   - adding `format` for `.datetime()`, `.uuid()`, `.email()` and `.url()` and `pattern` for `.regex()` is also supported

--- a/spec/modifiers/pipe.spec.ts
+++ b/spec/modifiers/pipe.spec.ts
@@ -2,10 +2,6 @@ import { z } from 'zod';
 import { expectSchema, registerSchema } from '../lib/helpers';
 
 describe('pipe', () => {
-  z.string()
-    .transform(val => val.length)
-    .pipe(z.number().min(5));
-
   it('can generate schema for pipes', () => {
     expectSchema(
       [

--- a/spec/modifiers/pipe.spec.ts
+++ b/spec/modifiers/pipe.spec.ts
@@ -1,0 +1,39 @@
+import { z } from 'zod';
+import { expectSchema, registerSchema } from '../lib/helpers';
+
+describe('pipe', () => {
+  z.string()
+    .transform(val => val.length)
+    .pipe(z.number().min(5));
+
+  it('can generate schema for pipes', () => {
+    expectSchema(
+      [
+        registerSchema(
+          'PipedDate',
+          z.date().or(z.string().min(1).pipe(z.coerce.date()))
+        ),
+      ],
+      {
+        PipedDate: {
+          anyOf: [{ type: 'string' }, { type: 'string', minLength: 1 }],
+        },
+      },
+      '3.1.0'
+    );
+  });
+
+  it('can generate schema for pipes with internal type transformation', () => {
+    expectSchema(
+      [
+        registerSchema(
+          'PipedNumber',
+          z.number().or(z.string()).pipe(z.coerce.number())
+        ),
+      ],
+      {
+        PipedNumber: { anyOf: [{ type: 'number' }, { type: 'string' }] },
+      }
+    );
+  });
+});

--- a/src/lib/zod-is-type.ts
+++ b/src/lib/zod-is-type.ts
@@ -15,6 +15,7 @@ type ZodTypes = {
   ZodNumber: z.ZodNumber;
   ZodObject: z.AnyZodObject;
   ZodOptional: z.ZodOptional<any>;
+  ZodPipeline: z.ZodPipeline<any, any>;
   ZodRecord: z.ZodRecord;
   ZodSchema: z.ZodSchema;
   ZodString: z.ZodString;

--- a/src/openapi-generator.ts
+++ b/src/openapi-generator.ts
@@ -974,6 +974,10 @@ export class OpenAPIGenerator {
       };
     }
 
+    if (isZodType(zodSchema, 'ZodPipeline')) {
+      return this.toOpenAPISchema(zodSchema._def.in, isNullable, defaultValue);
+    }
+
     const refId = this.getMetadata(zodSchema)?._internal?.refId;
 
     throw new UnknownZodTypeError({


### PR DESCRIPTION
Based on the [documentation](https://zod.dev/?id=pipe) it seems that we can generate a documentation for `ZodPipeline`.

However we do have two options:
1. Use the `in` property saved within the zod schema (done in the PR). My thought process was that this is what an API would receive when this schema is used for validation.
2. Use the `out` property as it describes the target state (might not always be the case).

Overall I feel like `in` is the only correct option we can use. But saying that it does bring up the question why cannot we just use the same logic when handling the result of `.transform()`. @georgyangelov any thoughts would be appreciated.