### PR TITLE
Fix vulnerability in yaml

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "4.6.0",
       "license": "MIT",
       "dependencies": {
-        "openapi3-ts": "^3.1.1"
+        "openapi3-ts": "^4.1.2"
       },
       "devDependencies": {
         "@types/jest": "^29.2.5",
@@ -17,7 +17,7 @@
         "prettier": "^2.7.1",
         "ts-jest": "^29.0.3",
         "typescript": "^4.6.3",
-        "yaml": "^2.0.0",
+        "yaml": "^2.2.2",
         "zod": "^3.20.2"
       },
       "peerDependencies": {
@@ -2831,11 +2831,11 @@
       }
     },
     "node_modules/openapi3-ts": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/openapi3-ts/-/openapi3-ts-3.1.1.tgz",
-      "integrity": "sha512-lNUS87ncFqm1m8W21sbTGIeD7sydkQ4nnRUrkBiGlAzTngr50eBKU2suUXhdEk51z6m4cCgaXdB1SFgXtyn81Q==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/openapi3-ts/-/openapi3-ts-4.1.2.tgz",
+      "integrity": "sha512-B7gOkwsYMZO7BZXwJzXCuVagym2xhqsrilVvV0dnq2Di4+iLUXKVX9gOK23ZqaAHZOwABXN0QTdW8QnkUTX6DA==",
       "dependencies": {
-        "yaml": "^2.1.3"
+        "yaml": "^2.2.2"
       }
     },
     "node_modules/p-limit": {
@@ -5748,11 +5748,11 @@
       }
     },
     "openapi3-ts": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/openapi3-ts/-/openapi3-ts-3.1.1.tgz",
-      "integrity": "sha512-lNUS87ncFqm1m8W21sbTGIeD7sydkQ4nnRUrkBiGlAzTngr50eBKU2suUXhdEk51z6m4cCgaXdB1SFgXtyn81Q==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/openapi3-ts/-/openapi3-ts-4.1.2.tgz",
+      "integrity": "sha512-B7gOkwsYMZO7BZXwJzXCuVagym2xhqsrilVvV0dnq2Di4+iLUXKVX9gOK23ZqaAHZOwABXN0QTdW8QnkUTX6DA==",
       "requires": {
-        "yaml": "^2.1.3"
+        "yaml": "^2.2.2"
       }
     },
     "p-limit": {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "prepublishOnly": "npm run build"
   },
   "dependencies": {
-    "openapi3-ts": "^3.1.1"
+    "openapi3-ts": "^4.1.2"
   },
   "peerDependencies": {
     "zod": "^3.20.2"
@@ -41,7 +41,7 @@
     "prettier": "^2.7.1",
     "ts-jest": "^29.0.3",
     "typescript": "^4.6.3",
-    "yaml": "^2.0.0",
+    "yaml": "^2.2.2",
     "zod": "^3.20.2"
   },
   "author": "Astea Solutions <info@asteasolutions.com>",

--- a/spec/custom-components.spec.ts
+++ b/spec/custom-components.spec.ts
@@ -53,7 +53,7 @@ describe('Custom components', () => {
     });
 
     const builder = new OpenAPIGenerator(registry.definitions, '3.0.0');
-    const document = builder.generateDocument(testDocConfig);
+    const document = builder.generateDocument(testDocConfig) as any;
 
     expect(document.paths['/units'].get.security).toEqual([{ bearerAuth: [] }]);
 
@@ -92,7 +92,7 @@ describe('Custom components', () => {
     });
 
     const builder = new OpenAPIGenerator(registry.definitions, '3.0.0');
-    const document = builder.generateDocument(testDocConfig);
+    const document = builder.generateDocument(testDocConfig) as any;
 
     expect(document.paths['/units'].get.responses['200'].headers).toEqual({
       'x-api-key': { $ref: '#/components/headers/api-key' },

--- a/spec/lib/helpers.ts
+++ b/spec/lib/helpers.ts
@@ -3,7 +3,7 @@ import {
   OpenAPIObjectConfig,
   OpenApiVersion,
 } from '../../src/openapi-generator';
-import type { SchemasObject } from 'openapi3-ts';
+import type { SchemasObject } from 'openapi3-ts/oas30';
 import type { ZodSchema } from 'zod';
 import { OpenAPIRegistry, RouteConfig } from '../../src/openapi-registry';
 

--- a/spec/routes/index.spec.ts
+++ b/spec/routes/index.spec.ts
@@ -1,5 +1,5 @@
 import { z, ZodSchema } from 'zod';
-import { OperationObject, PathItemObject } from 'openapi3-ts';
+import { OperationObject, PathItemObject } from 'openapi3-ts/oas30';
 import { OpenAPIGenerator } from '../../src/openapi-generator';
 import { OpenAPIRegistry, RouteConfig } from '../../src/openapi-registry';
 import { createTestRoute, registerSchema, testDocConfig } from '../lib/helpers';
@@ -42,7 +42,7 @@ const routeTests = ({
       const document = new OpenAPIGenerator(
         registry.definitions,
         '3.0.0'
-      ).generateDocument(testDocConfig);
+      ).generateDocument(testDocConfig) as any;
       const responses = document[rootDocPath]?.['/'].get.responses;
 
       expect(responses['200'].description).toEqual('Simple response');
@@ -84,7 +84,7 @@ const routeTests = ({
       const document = new OpenAPIGenerator(
         registry.definitions,
         '3.0.0'
-      ).generateDocument(testDocConfig);
+      ).generateDocument(testDocConfig) as any;
       const responses = document[rootDocPath]?.['/'].get.responses;
 
       expect(responses['200'].content['application/json'].schema).toEqual({
@@ -125,7 +125,7 @@ const routeTests = ({
       const document = new OpenAPIGenerator(
         registry.definitions,
         '3.0.0'
-      ).generateDocument(testDocConfig);
+      ).generateDocument(testDocConfig) as any;
       const responses = document[rootDocPath]?.['/'].get.responses;
 
       expect(responses['200'].description).toEqual('Simple response');
@@ -153,7 +153,7 @@ const routeTests = ({
       const document = new OpenAPIGenerator(
         registry.definitions,
         '3.0.0'
-      ).generateDocument(testDocConfig);
+      ).generateDocument(testDocConfig) as any;
       const responses = document[rootDocPath]?.['/'].get.responses;
 
       expect(responses['204']).toEqual({ description: 'Success' });
@@ -189,7 +189,7 @@ const routeTests = ({
     const document = new OpenAPIGenerator(
       registry.definitions,
       '3.0.0'
-    ).generateDocument(testDocConfig);
+    ).generateDocument(testDocConfig) as any;
     const responses = document[rootDocPath]?.['/'].get.responses;
 
     expect(responses['400']).toEqual(
@@ -231,7 +231,7 @@ const routeTests = ({
       const document = new OpenAPIGenerator(
         registry.definitions,
         '3.0.0'
-      ).generateDocument(testDocConfig);
+      ).generateDocument(testDocConfig) as any;
 
       const { requestBody } = document[rootDocPath]?.['/'].get;
 
@@ -268,7 +268,7 @@ const routeTests = ({
       const document = new OpenAPIGenerator(
         registry.definitions,
         '3.0.0'
-      ).generateDocument(testDocConfig);
+      ).generateDocument(testDocConfig) as any;
 
       const requestBody = document[rootDocPath]?.['/'].get.requestBody.content;
 
@@ -309,7 +309,7 @@ const routeTests = ({
       const document = new OpenAPIGenerator(
         registry.definitions,
         '3.0.0'
-      ).generateDocument(testDocConfig);
+      ).generateDocument(testDocConfig) as any;
 
       const requestBody = document[rootDocPath]?.['/'].get.requestBody.content;
 

--- a/spec/routes/parameters.spec.ts
+++ b/spec/routes/parameters.spec.ts
@@ -1,4 +1,4 @@
-import { OperationObject, PathItemObject } from 'openapi3-ts';
+import { OperationObject, PathItemObject } from 'openapi3-ts/oas30';
 import { z, ZodSchema } from 'zod';
 import { OpenAPIGenerator, RouteConfig } from '../../src';
 import { MissingParameterDataError } from '../../src/errors';

--- a/spec/types/number.spec.ts
+++ b/spec/types/number.spec.ts
@@ -58,7 +58,7 @@ describe('number', () => {
     expectSchema(
       [registerSchema('SimpleInteger', z.number().int().gt(0))],
       {
-        SimpleInteger: { type: 'integer', exclusiveMinimum: 0 },
+        SimpleInteger: { type: 'integer', exclusiveMinimum: 0 } as any,
       },
       '3.1.0'
     );
@@ -78,7 +78,7 @@ describe('number', () => {
     expectSchema(
       [registerSchema('SimpleInteger', z.number().int().lt(0))],
       {
-        SimpleInteger: { type: 'integer', exclusiveMaximum: 0 },
+        SimpleInteger: { type: 'integer', exclusiveMaximum: 0 } as any,
       },
       '3.1.0'
     );

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,4 +10,4 @@ export {
   ZodRequestBody,
 } from './openapi-registry';
 
-export * as OpenAPI from 'openapi3-ts';
+export * as OpenAPI from 'openapi3-ts/oas30';

--- a/src/openapi-generator.ts
+++ b/src/openapi-generator.ts
@@ -1,6 +1,5 @@
-import {
+import type {
   ReferenceObject,
-  SchemaObject,
   ParameterObject,
   RequestBodyObject,
   PathItemObject,
@@ -10,7 +9,11 @@ import {
   ResponseObject,
   ContentObject,
   DiscriminatorObject,
-} from 'openapi3-ts';
+  SchemaObject,
+} from 'openapi3-ts/oas30';
+
+import { PathsObject } from 'openapi3-ts/oas31';
+
 import type {
   AnyZodObject,
   ZodNumberDef,
@@ -692,18 +695,22 @@ export class OpenAPIGenerator {
       ...checks.map<SchemaObject>(check => {
         switch (check.kind) {
           case 'min':
-            return check.inclusive
-              ? { minimum: check.value }
-              : this.openApiVersionSatisfies(this.openAPIVersion, '3.1.0')
-              ? { exclusiveMinimum: check.value }
-              : { minimum: check.value, exclusiveMinimum: true };
+            return (
+              check.inclusive
+                ? { minimum: check.value }
+                : this.openApiVersionSatisfies(this.openAPIVersion, '3.1.0')
+                ? { exclusiveMinimum: check.value }
+                : { minimum: check.value, exclusiveMinimum: true }
+            ) as any; // TODO: Fix in a separate PR
 
           case 'max':
-            return check.inclusive
-              ? { maximum: check.value }
-              : this.openApiVersionSatisfies(this.openAPIVersion, '3.1.0')
-              ? { exclusiveMaximum: check.value }
-              : { maximum: check.value, exclusiveMaximum: true };
+            return (
+              check.inclusive
+                ? { maximum: check.value }
+                : this.openApiVersionSatisfies(this.openAPIVersion, '3.1.0')
+                ? { exclusiveMaximum: check.value }
+                : { maximum: check.value, exclusiveMaximum: true }
+            ) as any; // TODO: Fix in a separate PR
 
           default:
             return {};

--- a/src/openapi-registry.ts
+++ b/src/openapi-registry.ts
@@ -16,7 +16,7 @@ import {
   ResponseObject,
   SchemaObject,
   SecuritySchemeObject,
-} from 'openapi3-ts';
+} from 'openapi3-ts/oas30';
 import type { AnyZodObject, ZodSchema, ZodType } from 'zod';
 
 type Method =

--- a/src/zod-extensions.ts
+++ b/src/zod-extensions.ts
@@ -1,4 +1,4 @@
-import { ParameterObject, SchemaObject } from 'openapi3-ts';
+import { ParameterObject, SchemaObject } from 'openapi3-ts/oas30';
 import type { z, ZodObject, ZodRawShape } from 'zod';
 import { isZodType } from './lib/zod-is-type';
 


### PR DESCRIPTION
Note: This update lead to changes in the types of `openapi3-ts` related to the addition of OpenApi 3.1. I've currently take the "easier" approach for this update - i.e casting in 1 place in the generator and in a couple more in the tests.

In my opinion a better approach would be to do something like:
1. Separate implementation/type overloads of every method and schema based on the provided `openAPIVersion`.
2. Decision on what needs to be exposed as option for `.openapi`
  - It could be a "union" of schemas - that would however introduce new behavior to be implemented.
  - Or we can keep the current "old" schema (which "forbids" certain usages that are valid for 3.1)
  - We could also expose two overloads - something like `.openapi` and `.openapi31`. Again that would introduce new properties and cases that we should handle in the code

@georgyangelov @samchungy I am once again asking for opinion

Fixes: #122 

