### PR TITLE
added support for zod object for response headers

### DIFF
--- a/spec/routes/index.spec.ts
+++ b/spec/routes/index.spec.ts
@@ -1,8 +1,7 @@
-import { z, ZodSchema } from 'zod';
-import { OperationObject, PathItemObject } from 'openapi3-ts';
+import { z } from 'zod';
 import { OpenAPIGenerator } from '../../src/openapi-generator';
-import { OpenAPIRegistry, RouteConfig } from '../../src/openapi-registry';
-import { createTestRoute, registerSchema, testDocConfig } from '../lib/helpers';
+import { OpenAPIRegistry } from '../../src/openapi-registry';
+import { createTestRoute, testDocConfig } from '../lib/helpers';
 
 const routeTests = ({
   registerFunction,
@@ -157,6 +156,50 @@ const routeTests = ({
       const responses = document[rootDocPath]?.['/'].get.responses;
 
       expect(responses['204']).toEqual({ description: 'Success' });
+    });
+
+    it('can generate response headers', () => {
+      const registry = new OpenAPIRegistry();
+
+      registry[registerFunction]({
+        method: 'get',
+        path: '/',
+        responses: {
+          204: {
+            description: 'Success',
+            headers: z.object({
+              'Set-Cookie': z.string().openapi({
+                example: 'token=test',
+                description: 'Some string value',
+                param: {
+                  description: 'JWT session cookie',
+                },
+              }),
+            }),
+          },
+        },
+      });
+
+      const document = new OpenAPIGenerator(
+        registry.definitions,
+        '3.0.0'
+      ).generateDocument(testDocConfig);
+      const responses = document[rootDocPath]?.['/'].get.responses;
+
+      expect(responses['204']).toEqual({
+        description: 'Success',
+        headers: {
+          'Set-Cookie': {
+            schema: {
+              type: 'string',
+              example: 'token=test',
+              description: 'Some string value',
+            },
+            description: 'JWT session cookie',
+            required: true,
+          },
+        },
+      });
     });
   });
 

--- a/src/openapi-registry.ts
+++ b/src/openapi-registry.ts
@@ -48,7 +48,7 @@ export interface ZodRequestBody {
 
 export interface ResponseConfig {
   description: string;
-  headers?: HeadersObject;
+  headers?: AnyZodObject | HeadersObject;
   links?: LinksObject;
   content?: ZodContentObject;
 }


### PR DESCRIPTION
Resolves #116.

Side note: right now there are 3 approaches to generate response headers:
1. Directly specifying a `HeadersObject` through the response 
```
responses: {
  204: {
    description: 'Success',
    headers: { 'Set-Cookie': { schema: { type: 'string' } } },
  },
},
```
2. Using custom components:
```
const apiKeyHeader = registry.registerComponent('headers', 'api-key', {
      example: '1234',
      required: true,
    });

// ...
responses: {
  200: { description: 'Sample response', headers: { 'x-api-key': apiKeyHeader.ref }  }
};
```
3. Using ZodObject:
```
responses: {
  204: {
    description: 'Success',
    headers: z.object({
      'Set-Cookie': z.string().openapi({ example: 'token=test' }),
    }),
  },
},
```

However I do feel that all are valid because:
1. Obviouslly we should allow plain documentation to be written as everywhere else in the codde
2. The custom schemas are a mechanism that can be utilized for response headers but are not necessarily made for that
3. Adding support for ZodObject seems logical since this is something that could be validated and it is a convenience to support.