### PR TITLE
prepare script to build when npm install from git

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   "homepage": "https://github.com/asteasolutions/zod-to-openapi",
   "scripts": {
     "build": "tsc -p tsconfig.build.json",
+    "prepare": "npm run build",
     "test": "jest",
     "prettier": "prettier --write .",
     "lint": "prettier --check .",


### PR DESCRIPTION
When I ran `npm install --package-lock git+https://github.com/asteasolutions/zod-to-openapi.git#5c9ae89` to use the latest code changes, it does not install js files, so my code fails with:

```
Error: Cannot find module '/Users/user/app/node_modules/@asteasolutions/zod-to-openapi/dist/index.js'. Please verify that the package.json has a valid "main" entry
```

This fix adds a `prepare` script to run `npm run build`.
