### PR TITLE
Bugfix/#132: Keep inner param metadata to fix deepPartial nested object params

### DIFF
--- a/spec/routes/parameters.spec.ts
+++ b/spec/routes/parameters.spec.ts
@@ -21,6 +21,37 @@ describe('parameters', () => {
       ]);
     });
 
+    it('generates a deepPartial object query parameter for route', () => {
+      const { parameters } = generateDataForRoute({
+        request: {
+          query: z
+            .object({
+              filter: z
+                .object({ test: z.string() })
+                .openapi({ param: { style: 'deepObject' } }),
+            })
+            .deepPartial(),
+        },
+      });
+
+      expect(parameters).toEqual([
+        {
+          in: 'query',
+          name: 'filter',
+          required: false,
+          style: 'deepObject',
+          schema: {
+            type: 'object',
+            properties: {
+              test: {
+                type: 'string',
+              },
+            },
+          },
+        },
+      ]);
+    });
+
     it('generates a reference query parameter for route', () => {
       const TestQuery = registerParameter(
         'TestQuery',

--- a/src/openapi-generator.ts
+++ b/src/openapi-generator.ts
@@ -311,7 +311,9 @@ export class OpenAPIGenerator {
         }
 
         return this.generateParameter(
-          schema.openapi({ param: { name: key, in: location } })
+          schema.openapi({
+            param: { name: key, in: location, ...innerParameterMetadata },
+          })
         );
       });
 


### PR DESCRIPTION
This PR supposed to fix [issue](https://github.com/asteasolutions/zod-to-openapi/issues/132) when openapi metadata is being list when using inside deepPartial object schema. The problem occurred because of calling `openapi()` on the top level schema:
```ts
        return this.generateParameter(
          schema.openapi({ param: { name: key, in: location } })
        );
```

The above call added metadata to the top level schema which could be `ZodOptional` in case of `deepPartial()`, so after that, when `getMetadata()` was called from `generateParameter()`, it didn't return metadata from inner object:
```ts
    const metadata = zodSchema._def.openapi
      ? zodSchema._def.openapi // <-- Metadata already exists at the top level when generating param
      : innerSchema._def.openapi;
```

To fix this, I added inner param metadata to the top level. Please check my solution and let me know if it works. Thanks!