### PR TITLE
Use ZodTypeAny instead of ZodSchema<any>

### DIFF
--- a/spec/lib/helpers.ts
+++ b/spec/lib/helpers.ts
@@ -8,7 +8,7 @@ import type {
   OperationObject,
   SchemasObject,
 } from 'openapi3-ts/oas30';
-import type { ZodSchema } from 'zod';
+import type { ZodSchema, ZodTypeAny } from 'zod';
 import {
   OpenAPIDefinitions,
   OpenAPIRegistry,
@@ -16,7 +16,7 @@ import {
 } from '../../src/openapi-registry';
 
 export function createSchemas(
-  zodSchemas: ZodSchema<any>[],
+  zodSchemas: ZodTypeAny[],
   openApiVersion: OpenApiVersion = '3.0.0'
 ) {
   const definitions = zodSchemas.map(schema => ({
@@ -33,7 +33,7 @@ export function createSchemas(
 }
 
 export function expectSchema(
-  zodSchemas: ZodSchema<any>[],
+  zodSchemas: ZodTypeAny[],
   openAPISchemas: SchemasObject,
   openApiVersion: OpenApiVersion = '3.0.0'
 ) {
@@ -42,7 +42,7 @@ export function expectSchema(
   expect(components?.['schemas']).toEqual(openAPISchemas);
 }
 
-export function registerParameter<T extends ZodSchema<any>>(
+export function registerParameter<T extends ZodTypeAny>(
   refId: string,
   zodSchema: T
 ) {

--- a/spec/lib/helpers.ts
+++ b/spec/lib/helpers.ts
@@ -8,7 +8,7 @@ import type {
   OperationObject,
   SchemasObject,
 } from 'openapi3-ts/oas30';
-import type { ZodSchema, ZodTypeAny } from 'zod';
+import type { ZodTypeAny } from 'zod';
 import {
   OpenAPIDefinitions,
   OpenAPIRegistry,

--- a/src/openapi-generator.ts
+++ b/src/openapi-generator.ts
@@ -192,7 +192,7 @@ export class OpenAPIGenerator {
   }
 
   private generateParameterDefinition(
-    zodSchema: ZodSchema<any>
+    zodSchema: ZodTypeAny
   ): ParameterObject | ReferenceObject {
     const refId = this.getRefId(zodSchema);
 
@@ -256,7 +256,7 @@ export class OpenAPIGenerator {
   }
 
   private generateInlineParameters(
-    zodSchema: ZodSchema<any>,
+    zodSchema: ZodTypeAny,
     location: ParameterLocation
   ): (ParameterObject | ReferenceObject)[] {
     const metadata = this.getMetadata(zodSchema);
@@ -333,9 +333,7 @@ export class OpenAPIGenerator {
     ];
   }
 
-  private generateSimpleParameter(
-    zodSchema: ZodSchema<any>
-  ): BaseParameterObject {
+  private generateSimpleParameter(zodSchema: ZodTypeAny): BaseParameterObject {
     const metadata = this.getMetadata(zodSchema);
     const paramMetadata = metadata?.metadata?.param;
 
@@ -351,7 +349,7 @@ export class OpenAPIGenerator {
     };
   }
 
-  private generateParameter(zodSchema: ZodSchema<any>): ParameterObject {
+  private generateParameter(zodSchema: ZodTypeAny): ParameterObject {
     const metadata = this.getMetadata(zodSchema);
 
     const paramMetadata = metadata?.metadata?.param;
@@ -450,7 +448,7 @@ export class OpenAPIGenerator {
    * Generates a whole OpenApi schema and saves it into
    * schemaRefs if a `refId` is provided.
    */
-  private generateSchema(zodSchema: ZodSchema<any>) {
+  private generateSchema(zodSchema: ZodTypeAny) {
     const refId = this.getRefId(zodSchema);
 
     const result = this.generateSimpleSchema(zodSchema);
@@ -469,7 +467,7 @@ export class OpenAPIGenerator {
    *
    * Should be used for nested objects, arrays, etc.
    */
-  private generateSchemaWithRef(zodSchema: ZodSchema<any>) {
+  private generateSchemaWithRef(zodSchema: ZodTypeAny) {
     const refId = this.getRefId(zodSchema);
 
     const result = this.generateSimpleSchema(zodSchema);
@@ -866,7 +864,7 @@ export class OpenAPIGenerator {
       (zodSchema._def.effect.type === 'refinement' ||
         zodSchema._def.effect.type === 'preprocess')
     ) {
-      const innerSchema = zodSchema._def.schema as ZodSchema<any>;
+      const innerSchema = zodSchema._def.schema as ZodTypeAny;
       // Here we want to register any underlying schemas, however we do not want to
       // reference it, hence why `generateSchema` is used instead of `generateSchemaWithRef`
       return this.generateSchema(innerSchema);
@@ -928,7 +926,7 @@ export class OpenAPIGenerator {
     }
 
     if (isZodType(zodSchema, 'ZodArray')) {
-      const itemType = zodSchema._def.type as ZodSchema<any>;
+      const itemType = zodSchema._def.type as ZodTypeAny;
 
       return {
         ...this.mapNullableType('array', isNullable),
@@ -1162,17 +1160,17 @@ export class OpenAPIGenerator {
     };
   }
 
-  private flattenUnionTypes(schema: ZodSchema<any>): ZodSchema<any>[] {
+  private flattenUnionTypes(schema: ZodTypeAny): ZodTypeAny[] {
     if (!isZodType(schema, 'ZodUnion')) {
       return [schema];
     }
 
-    const options = schema._def.options as ZodSchema<any>[];
+    const options = schema._def.options as ZodTypeAny[];
 
     return options.flatMap(option => this.flattenUnionTypes(option));
   }
 
-  private flattenIntersectionTypes(schema: ZodSchema<any>): ZodSchema<any>[] {
+  private flattenIntersectionTypes(schema: ZodTypeAny): ZodTypeAny[] {
     if (!isZodType(schema, 'ZodIntersection')) {
       return [schema];
     }
@@ -1183,7 +1181,7 @@ export class OpenAPIGenerator {
     return [...leftSubTypes, ...rightSubTypes];
   }
 
-  private unwrapChained(schema: ZodSchema<any>): ZodSchema<any> {
+  private unwrapChained(schema: ZodTypeAny): ZodTypeAny {
     if (
       isZodType(schema, 'ZodOptional') ||
       isZodType(schema, 'ZodNullable') ||

--- a/src/openapi-metadata.ts
+++ b/src/openapi-metadata.ts
@@ -1,6 +1,6 @@
-import { ZodSchema } from 'zod';
+import { ZodSchema, ZodTypeAny } from 'zod';
 import { isNil, omitBy } from './lib/lodash';
 
-export function getOpenApiMetadata<T extends ZodSchema<any>>(zodSchema: T) {
+export function getOpenApiMetadata<T extends ZodTypeAny>(zodSchema: T) {
   return omitBy(zodSchema._def.openapi?.metadata ?? {}, isNil);
 }

--- a/src/openapi-metadata.ts
+++ b/src/openapi-metadata.ts
@@ -1,4 +1,4 @@
-import { ZodSchema, ZodTypeAny } from 'zod';
+import { ZodTypeAny } from 'zod';
 import { isNil, omitBy } from './lib/lodash';
 
 export function getOpenApiMetadata<T extends ZodTypeAny>(zodSchema: T) {

--- a/src/openapi-registry.ts
+++ b/src/openapi-registry.ts
@@ -17,7 +17,7 @@ import {
   SchemaObject,
   SecuritySchemeObject,
 } from 'openapi3-ts/oas30';
-import type { AnyZodObject, ZodSchema, ZodType } from 'zod';
+import type { AnyZodObject, ZodSchema, ZodType, ZodTypeAny } from 'zod';
 
 type Method =
   | 'get'
@@ -91,8 +91,8 @@ export type OpenAPIDefinitions =
       name: string;
       component: OpenAPIComponentObject;
     }
-  | { type: 'schema'; schema: ZodSchema<any> }
-  | { type: 'parameter'; schema: ZodSchema<any> }
+  | { type: 'schema'; schema: ZodTypeAny }
+  | { type: 'parameter'; schema: ZodTypeAny }
   | { type: 'route'; route: RouteConfig }
   | { type: 'webhook'; webhook: RouteConfig };
 
@@ -111,7 +111,7 @@ export class OpenAPIRegistry {
   /**
    * Registers a new component schema under /components/schemas/${name}
    */
-  register<T extends ZodSchema<any>>(refId: string, zodSchema: T): T {
+  register<T extends ZodTypeAny>(refId: string, zodSchema: T): T {
     const schemaWithRefId = this.schemaWithRefId(refId, zodSchema);
 
     this._definitions.push({ type: 'schema', schema: schemaWithRefId });
@@ -122,7 +122,7 @@ export class OpenAPIRegistry {
   /**
    * Registers a new parameter schema under /components/parameters/${name}
    */
-  registerParameter<T extends ZodSchema<any>>(refId: string, zodSchema: T) {
+  registerParameter<T extends ZodTypeAny>(refId: string, zodSchema: T) {
     const schemaWithRefId = this.schemaWithRefId(refId, zodSchema);
 
     const currentMetadata = schemaWithRefId._def.openapi?.metadata;
@@ -189,7 +189,7 @@ export class OpenAPIRegistry {
     };
   }
 
-  private schemaWithRefId<T extends ZodSchema<any>>(
+  private schemaWithRefId<T extends ZodTypeAny>(
     refId: string,
     zodSchema: T
   ): T {

--- a/src/openapi-registry.ts
+++ b/src/openapi-registry.ts
@@ -17,7 +17,7 @@ import {
   SchemaObject,
   SecuritySchemeObject,
 } from 'openapi3-ts/oas30';
-import type { AnyZodObject, ZodSchema, ZodType, ZodTypeAny } from 'zod';
+import type { AnyZodObject, ZodType, ZodTypeAny } from 'zod';
 
 type Method =
   | 'get'

--- a/src/zod-extensions.ts
+++ b/src/zod-extensions.ts
@@ -27,7 +27,11 @@ declare module 'zod' {
     openapi?: ZodOpenApiFullMetadata;
   }
 
-  interface ZodSchema<Output, Def extends ZodTypeDef, Input = Output> {
+  interface ZodType<
+    Output = any,
+    Def extends ZodTypeDef = ZodTypeDef,
+    Input = Output
+  > {
     openapi<T extends ZodTypeAny>(
       this: T,
       metadata: Partial<ZodOpenAPIMetadata<z.infer<T>>>
@@ -42,14 +46,14 @@ declare module 'zod' {
 }
 
 export function extendZodWithOpenApi(zod: typeof z) {
-  if (typeof zod.ZodSchema.prototype.openapi !== 'undefined') {
+  if (typeof zod.ZodType.prototype.openapi !== 'undefined') {
     // This zod instance is already extended with the required methods,
     // doing it again will just result in multiple wrapper methods for
     // `optional` and `nullable`
     return;
   }
 
-  zod.ZodSchema.prototype.openapi = function (
+  zod.ZodType.prototype.openapi = function (
     refOrOpenapi: string | Partial<ZodOpenAPIMetadata<any>>,
     metadata?: Partial<ZodOpenAPIMetadata<any>>
   ) {
@@ -109,8 +113,8 @@ export function extendZodWithOpenApi(zod: typeof z) {
     return result;
   };
 
-  const zodOptional = zod.ZodSchema.prototype.optional as any;
-  (zod.ZodSchema.prototype.optional as any) = function (
+  const zodOptional = zod.ZodType.prototype.optional as any;
+  (zod.ZodType.prototype.optional as any) = function (
     this: any,
     ...args: any[]
   ) {
@@ -121,8 +125,8 @@ export function extendZodWithOpenApi(zod: typeof z) {
     return result;
   };
 
-  const zodNullable = zod.ZodSchema.prototype.nullable as any;
-  (zod.ZodSchema.prototype.nullable as any) = function (
+  const zodNullable = zod.ZodType.prototype.nullable as any;
+  (zod.ZodType.prototype.nullable as any) = function (
     this: any,
     ...args: any[]
   ) {
@@ -133,8 +137,8 @@ export function extendZodWithOpenApi(zod: typeof z) {
     return result;
   };
 
-  const zodDefault = zod.ZodSchema.prototype.default as any;
-  (zod.ZodSchema.prototype.default as any) = function (
+  const zodDefault = zod.ZodType.prototype.default as any;
+  (zod.ZodType.prototype.default as any) = function (
     this: any,
     ...args: any[]
   ) {

--- a/src/zod-extensions.ts
+++ b/src/zod-extensions.ts
@@ -1,5 +1,5 @@
 import { ParameterObject, SchemaObject } from 'openapi3-ts/oas30';
-import type { z, ZodObject, ZodRawShape } from 'zod';
+import type { z, ZodObject, ZodRawShape, ZodTypeAny } from 'zod';
 import { isZodType } from './lib/zod-is-type';
 
 type ExampleValue<T> = T extends Date ? string : T;
@@ -28,12 +28,12 @@ declare module 'zod' {
   }
 
   interface ZodSchema<Output, Def extends ZodTypeDef, Input = Output> {
-    openapi<T extends ZodSchema<any>>(
+    openapi<T extends ZodTypeAny>(
       this: T,
       metadata: Partial<ZodOpenAPIMetadata<z.infer<T>>>
     ): T;
 
-    openapi<T extends ZodSchema<any>>(
+    openapi<T extends ZodTypeAny>(
       this: T,
       refId: string,
       metadata?: Partial<ZodOpenAPIMetadata<z.infer<T>>>


### PR DESCRIPTION
As specified here https://zod.dev/?id=writing-generic-functions `ZodTypeAny` is a better way to handle a generic schema parameter compared to `ZodSchema<any>`.
This PR is also needed to allow smoother interoperability between this and other libraries that manipulate the default `Zod` types