### PR TITLE
Bugfix/#143 handle preprocess and any

### DIFF
--- a/README.md
+++ b/README.md
@@ -490,6 +490,7 @@ Then you can create a script that executes the exported `generateOpenAPI` functi
 
 The list of all supported types as of now is:
 
+- `ZodAny`
 - `ZodArray`
 - `ZodBoolean`
 - `ZodDate`

--- a/spec/modifiers/refine.spec.ts
+++ b/spec/modifiers/refine.spec.ts
@@ -18,6 +18,24 @@ describe('refine', () => {
     );
   });
 
+  it('does not loose metadata from refine', () => {
+    expectSchema(
+      [
+        z
+          .number()
+          .openapi({ example: 42 })
+          .refine(num => num % 2 === 0)
+          .openapi('RefinedString'),
+      ],
+      {
+        RefinedString: {
+          type: 'number',
+          example: 42,
+        },
+      }
+    );
+  });
+
   it('supports required refined schemas', () => {
     expectSchema(
       [

--- a/spec/modifiers/refine.spec.ts
+++ b/spec/modifiers/refine.spec.ts
@@ -18,7 +18,7 @@ describe('refine', () => {
     );
   });
 
-  it('does not loose metadata from refine', () => {
+  it('does not lose metadata from refine', () => {
     expectSchema(
       [
         z

--- a/spec/modifiers/transform.spec.ts
+++ b/spec/modifiers/transform.spec.ts
@@ -14,8 +14,25 @@ describe('transform', () => {
         Transformed: {
           type: 'number',
         },
-      },
-      '3.1.0'
+      }
+    );
+  });
+
+  it('does not loose metadata from transform', () => {
+    expectSchema(
+      [
+        z
+          .number()
+          .openapi({ example: 42 })
+          .transform(num => num.toString())
+          .openapi('Transformed'),
+      ],
+      {
+        Transformed: {
+          type: 'number',
+          example: 42,
+        },
+      }
     );
   });
 });

--- a/spec/modifiers/transform.spec.ts
+++ b/spec/modifiers/transform.spec.ts
@@ -18,7 +18,7 @@ describe('transform', () => {
     );
   });
 
-  it('does not loose metadata from transform', () => {
+  it('does not lose metadata from transform', () => {
     expectSchema(
       [
         z

--- a/spec/types/any.spec.ts
+++ b/spec/types/any.spec.ts
@@ -1,0 +1,22 @@
+import { z } from 'zod';
+import { expectSchema } from '../lib/helpers';
+
+// Based on the "Any Type" section of https://swagger.io/docs/specification/data-models/data-types/
+
+describe('any', () => {
+  it('supports any for 3.0.0 ', () => {
+    expectSchema([z.any().openapi('Any', { description: 'Something' })], {
+      Any: { description: 'Something', nullable: true },
+    });
+  });
+
+  it('supports any for 3.1.0', () => {
+    expectSchema(
+      [z.any().openapi('Any', { description: 'Something' })],
+      {
+        Any: { description: 'Something' },
+      },
+      '3.1.0'
+    );
+  });
+});

--- a/spec/types/unknown.spec.ts
+++ b/spec/types/unknown.spec.ts
@@ -2,12 +2,22 @@ import { z } from 'zod';
 import { expectSchema } from '../lib/helpers';
 
 describe('unknown', () => {
-  it('supports unknown', () => {
+  it('supports unknown for 3.0.0 ', () => {
+    expectSchema(
+      [z.unknown().openapi('Unknown', { description: 'Something unknown' })],
+      {
+        Unknown: { description: 'Something unknown', nullable: true },
+      }
+    );
+  });
+
+  it('supports unknown for 3.1.0', () => {
     expectSchema(
       [z.unknown().openapi('Unknown', { description: 'Something unknown' })],
       {
         Unknown: { description: 'Something unknown' },
-      }
+      },
+      '3.1.0'
     );
   });
 });

--- a/spec/types/unknown.spec.ts
+++ b/spec/types/unknown.spec.ts
@@ -1,6 +1,8 @@
 import { z } from 'zod';
 import { expectSchema } from '../lib/helpers';
 
+// Based on the "Any Type" section of https://swagger.io/docs/specification/data-models/data-types/
+
 describe('unknown', () => {
   it('supports unknown for 3.0.0 ', () => {
     expectSchema(

--- a/src/lib/zod-is-type.ts
+++ b/src/lib/zod-is-type.ts
@@ -1,6 +1,7 @@
 import type { z } from 'zod';
 
 type ZodTypes = {
+  ZodAny: z.ZodAny;
   ZodArray: z.ZodArray<any>;
   ZodBoolean: z.ZodBoolean;
   ZodBranded: z.ZodBranded<any, any>;

--- a/src/openapi-generator.ts
+++ b/src/openapi-generator.ts
@@ -987,7 +987,7 @@ export class OpenAPIGenerator {
       };
     }
 
-    if (isZodType(zodSchema, 'ZodUnknown')) {
+    if (isZodType(zodSchema, 'ZodUnknown') || isZodType(zodSchema, 'ZodAny')) {
       return this.mapNullableType(undefined, isNullable);
     }
 

--- a/src/openapi-generator.ts
+++ b/src/openapi-generator.ts
@@ -821,11 +821,7 @@ export class OpenAPIGenerator {
       };
     }
 
-    if (
-      isZodType(zodSchema, 'ZodEffects') &&
-      (zodSchema._def.effect.type === 'refinement' ||
-        zodSchema._def.effect.type === 'preprocess')
-    ) {
+    if (isZodType(zodSchema, 'ZodEffects')) {
       const innerSchema = zodSchema._def.schema as ZodTypeAny;
       // Here we want to register any underlying schemas, however we do not want to
       // reference it, hence why `generateSchema` is used instead of `generateSchemaWithRef`
@@ -1156,11 +1152,7 @@ export class OpenAPIGenerator {
       return this.unwrapChained(schema._def.innerType);
     }
 
-    // TODO: preprocess should be passed here as well
-    if (
-      isZodType(schema, 'ZodEffects') &&
-      ['refinement', 'transform'].includes(schema._def.effect.type)
-    ) {
+    if (isZodType(schema, 'ZodEffects')) {
       return this.unwrapChained(schema._def.schema);
     }
 

--- a/src/openapi-generator.ts
+++ b/src/openapi-generator.ts
@@ -100,7 +100,7 @@ export interface OpenApiVersionSpecifics {
   mapNullableOfArray(objects: any[], isNullable: boolean): any[];
 
   mapNullableType(
-    type: NonNullable<SchemaObject['type']>,
+    type: NonNullable<SchemaObject['type']> | undefined,
     isNullable: boolean
   ): Pick<SchemaObject, 'type' | 'nullable'>;
 
@@ -739,7 +739,7 @@ export class OpenAPIGenerator {
   }
 
   private mapNullableType(
-    type: NonNullable<SchemaObject['type']>,
+    type: NonNullable<SchemaObject['type']> | undefined,
     isNullable: boolean
   ): Pick<SchemaObject, 'type' | 'nullable'> {
     return this.versionSpecifics.mapNullableType(type, isNullable);
@@ -992,7 +992,7 @@ export class OpenAPIGenerator {
     }
 
     if (isZodType(zodSchema, 'ZodUnknown')) {
-      return {};
+      return this.mapNullableType(undefined, isNullable);
     }
 
     if (isZodType(zodSchema, 'ZodDate')) {

--- a/src/v3.0/specifics.ts
+++ b/src/v3.0/specifics.ts
@@ -18,11 +18,11 @@ export class OpenApiGeneratorV30Specifics implements OpenApiVersionSpecifics {
   }
 
   mapNullableType(
-    type: NonNullable<SchemaObject['type']>,
+    type: NonNullable<SchemaObject['type']> | undefined,
     isNullable: boolean
   ): Pick<SchemaObject, 'type' | 'nullable'> {
     return {
-      type,
+      ...(type ? { type } : undefined),
       ...(isNullable ? this.nullType : undefined),
     };
   }

--- a/src/v3.1/specifics.ts
+++ b/src/v3.1/specifics.ts
@@ -19,9 +19,14 @@ export class OpenApiGeneratorV31Specifics implements OpenApiVersionSpecifics {
   }
 
   mapNullableType(
-    type: NonNullable<SchemaObject['type']>,
+    type: NonNullable<SchemaObject['type']> | undefined,
     isNullable: boolean
-  ): { type: SchemaObject['type'] } {
+  ): { type?: SchemaObject['type'] } {
+    if (!type) {
+      // 'null' is considered a type in Open API 3.1.0 => not providing a type includes null
+      return {};
+    }
+
     // Open API 3.1.0 made the `nullable` key invalid and instead you use type arrays
     if (isNullable) {
       return {


### PR DESCRIPTION
* Fixes #143
* Improves the handling of `z.unknown()` by adding `nullable: true` for 3.0.x
* Introduces support for `z.any()` - same as `z.unknown()` as per the "Any Type" section of https://swagger.io/docs/specification/data-models/data-types/
* Fixes #79 