### PR TITLE
Remove openapi3-ts exports

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -9,8 +9,5 @@ export {
   ZodRequestBody,
 } from './openapi-registry';
 
-export * as OpenAPIV3 from 'openapi3-ts/oas30';
-export * as OpenAPIV31 from 'openapi3-ts/oas31';
-
 export { OpenApiGeneratorV3 } from './v3.0/openapi-generator';
 export { OpenApiGeneratorV31 } from './v3.1/openapi-generator';


### PR DESCRIPTION
These exports seem wrong, you can just import directly from the `openapi3-ts` dependency without going through this library.

On top of that, they are actually the source of an error when using this project as a dependency in a `yarn` project:
```
Module not found: Can't resolve 'openapi3-ts/oas30' in '[...]/node_modules/@asteasolutions/zod-to-openapi/dist'
```

I believe it's safe to remove them, was there any specific reason why they were added?