### PR TITLE
WIP: force one of flag

### DIFF
--- a/src/openapi-generator.ts
+++ b/src/openapi-generator.ts
@@ -960,6 +960,14 @@ export class OpenAPIGenerator {
         return this.generateSchemaWithRef(optionToGenerate);
       });
 
+      const internalOptions = this.getOptions(zodSchema);
+      if (internalOptions.forceOneOf) {
+        return {
+          oneOf: this.mapNullableOfArray(schemas, isNullable),
+          default: defaultValue,
+        };
+      }
+
       return {
         anyOf: this.mapNullableOfArray(schemas, isNullable),
         default: defaultValue,
@@ -1292,6 +1300,10 @@ export class OpenAPIGenerator {
 
   private getRefId<T extends any>(zodSchema: ZodType<T>) {
     return this.getInternalMetadata(zodSchema)?.refId;
+  }
+
+  private getOptions<T extends any>(zodSchema: ZodType<T>) {
+    return this.getInternalMetadata(zodSchema)?.options;
   }
 
   private applySchemaMetadata(


### PR DESCRIPTION
Hey, I am working with an API that I cannot add discriminators to, but downstream generators can't consume AnyOf properly in some cases. 

Here are some similar threads:
https://github.com/asteasolutions/zod-to-openapi/issues/162
https://github.com/asteasolutions/zod-to-openapi/pull/163

This PR is a proposal for an interface to let a user opt into a potentially unsafe representation of their schema.

If the direction is approved, I can add testing / ensure correctness of my implementation -- I have not manually checked it yet for correctness, but want feedback on the interface & approach.