### PR TITLE
Added date-format to ZodDate

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5479,8 +5479,7 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.3.tgz",
       "integrity": "sha512-+3NpwQEnRoIBtx4fyhblQDPgJI0H1IEIkX7ShLUjPGA7TtUTvI1oiKi3SR4oBR0hQhQR80l4WAe5RrXBwWMA8w==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "jest-regex-util": {
       "version": "29.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5479,7 +5479,8 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.3.tgz",
       "integrity": "sha512-+3NpwQEnRoIBtx4fyhblQDPgJI0H1IEIkX7ShLUjPGA7TtUTvI1oiKi3SR4oBR0hQhQR80l4WAe5RrXBwWMA8w==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "jest-regex-util": {
       "version": "29.2.0",

--- a/src/openapi-generator.ts
+++ b/src/openapi-generator.ts
@@ -1025,6 +1025,7 @@ export class OpenAPIGenerator {
       return {
         ...this.mapNullableType('string', isNullable),
         default: defaultValue,
+        format: 'date-time',
       };
     }
 


### PR DESCRIPTION
I want to have my model be of date type but be rendered as date in openapi-generators. The only way to do this without having to hack the generator is to c;hange the openapi schema creatd from ZodDate objects to have a format type
