### PR TITLE
add autocompletion for media type

### DIFF
--- a/src/openapi-registry.ts
+++ b/src/openapi-registry.ts
@@ -77,9 +77,10 @@ export interface ZodMediaTypeObject {
   encoding?: EncodingObject;
 }
 
-export interface ZodContentObject {
-  [mediaType: string]: ZodMediaTypeObject;
-}
+// Provide autocompletion on media type with most common one without restricting to anything.
+export type ZodMediaType = 'application/json' | 'text/html' | 'text/plain' | 'application/xml' | string & {};
+
+export type ZodContentObject = Partial<Record<ZodMediaType, ZodMediaTypeObject>>;
 
 export interface ZodRequestBody {
   description?: string;


### PR DESCRIPTION
I've improve the type of ZodContentObject to provide autocompletion with most common media type without restricting the ability to put any string you want.