### PR TITLE
anyOf contains multiple nullable values with z.enum

### DIFF
--- a/spec/types/enum.spec.ts
+++ b/spec/types/enum.spec.ts
@@ -15,4 +15,17 @@ describe('enum', () => {
       },
     });
   });
+
+  it('does not contain multiple nullable values', () => {
+    const schema = z.union([z.enum(['option1', 'option2']), z.null()]).openapi('Enum');
+
+    expectSchema([schema], {
+      Enum: {
+        anyOf: [
+          { enum: ['option1', 'option2'], type: 'string' },
+          { nullable: true },
+        ],
+      },
+    });
+  });
 });


### PR DESCRIPTION
The current union / enum spec produces a lot of unnecessary duplicated nullable entries. I provided a failing testcase that reproduces the issue.