### PR TITLE
Add failing default 0 test

### DIFF
--- a/spec/modifiers/default.spec.ts
+++ b/spec/modifiers/default.spec.ts
@@ -128,6 +128,25 @@ describe('default', () => {
     );
   });
 
+  it('supports default of 0', () => {
+    expectSchema(
+      [z.object({ test: z.number().positive().default(0) }).openapi('Object')],
+      {
+        Object: {
+          type: 'object',
+          properties: {
+            test: {
+              type: 'number',
+              default: 0,
+              exclusiveMinimum: true,
+              minimum: 0,
+            },
+          },
+        },
+      }
+    );
+  });
+
   it('supports overriding default with .openapi', () => {
     expectSchema(
       [


### PR DESCRIPTION
When default is 0, the field is being marked as required