### PR TITLE
regex, time and duration string types

### DIFF
--- a/README.md
+++ b/README.md
@@ -560,6 +560,8 @@ The list of all supported types as of now is:
     - `.uuid()`
     - `.email()`
     - `.url()`
+    - `.duration()`
+    - `.time()`
   - adding `pattern` for `.regex()` is also supported
 
 

--- a/spec/types/string.spec.ts
+++ b/spec/types/string.spec.ts
@@ -51,6 +51,8 @@ describe('string', () => {
     ${'url'}      | ${z.string().url()}      | ${'uri'}
     ${'date'}     | ${z.string().date()}     | ${'date'}
     ${'datetime'} | ${z.string().datetime()} | ${'date-time'}
+    ${'duration'} | ${z.string().duration()} | ${'duration'}
+    ${'time'}     | ${z.string().time()}     | ${'time'}
   `(
     'maps a ZodString $format to $expected format',
     ({ zodString, expected }: { zodString: ZodString; expected: string }) => {

--- a/spec/types/string.spec.ts
+++ b/spec/types/string.spec.ts
@@ -71,7 +71,7 @@ describe('string', () => {
           .openapi('RegexString'),
       ],
       {
-        RegexString: { type: 'string', pattern: '^hello world' },
+        RegexString: { type: 'string', pattern: '^hello world', format: 'regex' },
       }
     );
   });

--- a/spec/types/string.spec.ts
+++ b/spec/types/string.spec.ts
@@ -71,7 +71,11 @@ describe('string', () => {
           .openapi('RegexString'),
       ],
       {
-        RegexString: { type: 'string', pattern: '^hello world', format: 'regex' },
+        RegexString: {
+          type: 'string',
+          pattern: '^hello world',
+          format: 'regex',
+        },
       }
     );
   });

--- a/src/transformers/string.ts
+++ b/src/transformers/string.ts
@@ -42,6 +42,7 @@ export class StringTransformer {
     if (zodString.isEmoji) return 'emoji';
     if (zodString.isTime) return 'time';
     if (zodString.isDuration) return 'duration';
+    if (this.getZodStringCheck(zodString, 'regex')) return 'regex';
 
     return undefined;
   }

--- a/src/transformers/string.ts
+++ b/src/transformers/string.ts
@@ -40,6 +40,8 @@ export class StringTransformer {
     if (zodString.isULID) return 'ulid';
     if (zodString.isIP) return 'ip';
     if (zodString.isEmoji) return 'emoji';
+    if (zodString.isTime) return 'time';
+    if (zodString.isDuration) return 'duration';
 
     return undefined;
   }


### PR DESCRIPTION
added regex, time and duration string types 

https://json-schema.org/understanding-json-schema/reference/string.html#built-in-formats

time and duration using zod built in functionality

because there is no isRegex zod function, i used
```js
this.getZodStringCheck(zodSchema, 'regex');
```