### PR TITLE
check for missing _internal when extending a non registered schema

### DIFF
--- a/src/zod-extensions.ts
+++ b/src/zod-extensions.ts
@@ -129,7 +129,7 @@ export function extendZodWithOpenApi(zod: typeof z) {
           _internal: {
             extendedFrom: this._def.openapi?._internal?.refId
               ? { refId: this._def.openapi?._internal?.refId, schema: this }
-              : this._def.openapi?._internal.extendedFrom,
+              : this._def.openapi?._internal?.extendedFrom,
           },
           metadata: extendedResult._def.openapi?.metadata,
         };


### PR DESCRIPTION
Fixes: #297 