### PR TITLE
[WIP] add support for zod-mini

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,10 +22,10 @@
         "ts-jest": "^29.0.3",
         "typescript": "^5.2.2",
         "yaml": "^2.2.2",
-        "zod": "~3.25.1"
+        "zod": "^3.25.1"
       },
       "peerDependencies": {
-        "zod": "~3.25.1"
+        "zod": "^3.25.1"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -4197,9 +4197,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "3.25.42",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.42.tgz",
-      "integrity": "sha512-PcALTLskaucbeHc41tU/xfjfhcz8z0GdhhDcSgrCTmSazUuqnYqiXO63M0QUBVwpBlsLsNVn5qHSC5Dw3KZvaQ==",
+      "version": "3.25.67",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.67.tgz",
+      "integrity": "sha512-idA2YXwpCdqUSKRCACDE6ItZD9TZzy3OZMtpfLoh6oPR47lipysRrJfjzMqFxQ3uJuUPyUeWe1r9vLH33xO/Qw==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -7300,9 +7300,9 @@
       "dev": true
     },
     "zod": {
-      "version": "3.25.42",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.42.tgz",
-      "integrity": "sha512-PcALTLskaucbeHc41tU/xfjfhcz8z0GdhhDcSgrCTmSazUuqnYqiXO63M0QUBVwpBlsLsNVn5qHSC5Dw3KZvaQ==",
+      "version": "3.25.67",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.67.tgz",
+      "integrity": "sha512-idA2YXwpCdqUSKRCACDE6ItZD9TZzy3OZMtpfLoh6oPR47lipysRrJfjzMqFxQ3uJuUPyUeWe1r9vLH33xO/Qw==",
       "dev": true
     }
   }

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "openapi3-ts": "^4.1.2"
   },
   "peerDependencies": {
-    "zod": "~3.25.1"
+    "zod": "^3.25.1"
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "^25.0.7",
@@ -48,7 +48,7 @@
     "ts-jest": "^29.0.3",
     "typescript": "^5.2.2",
     "yaml": "^2.2.2",
-    "zod": "~3.25.1"
+    "zod": "^3.25.1"
   },
   "author": "Astea Solutions <info@asteasolutions.com>",
   "license": "MIT"

--- a/spec/lib/helpers.ts
+++ b/spec/lib/helpers.ts
@@ -4,7 +4,7 @@ import type {
   SchemasObject as SchemasObjectV30,
 } from 'openapi3-ts/oas30';
 import type { SchemasObject as SchemasObjectV31 } from 'openapi3-ts/oas31';
-import type { ZodType } from 'zod/v4';
+import type { $ZodType } from 'zod/v4/core';
 import {
   OpenAPIDefinitions,
   OpenAPIRegistry,
@@ -16,9 +16,18 @@ import {
 } from '../../src/v3.0/openapi-generator';
 import { OpenApiGeneratorV31 } from '../../src/v3.1/openapi-generator';
 import { OpenApiVersion } from '../../src/openapi-generator';
+import type { ZodType } from 'zod/v4';
+
+export function registerSchemas(zodSchemas: Record<string, $ZodType>) {
+  const registry = new OpenAPIRegistry();
+
+  for (const [name, zodSchema] of Object.entries(zodSchemas)) {
+    registry.register(name, zodSchema);
+  }
+}
 
 export function createSchemas(
-  zodSchemas: ZodType[],
+  zodSchemas: $ZodType[],
   openApiVersion: OpenApiVersion = '3.0.0'
 ) {
   const definitions = zodSchemas.map(schema => ({
@@ -35,7 +44,7 @@ export function createSchemas(
 }
 
 export function expectSchema<T extends OpenApiVersion = '3.0.0'>(
-  zodSchemas: ZodType[],
+  zodSchemas: $ZodType[],
   openAPISchemas: T extends '3.1.0' ? SchemasObjectV31 : SchemasObjectV30,
   openApiVersion?: T
 ) {
@@ -44,7 +53,7 @@ export function expectSchema<T extends OpenApiVersion = '3.0.0'>(
   expect(components?.['schemas']).toEqual(openAPISchemas);
 }
 
-export function registerParameter<T extends ZodType>(
+export function registerParameter<T extends $ZodType>(
   refId: string,
   zodSchema: T
 ) {

--- a/spec/modifiers/branded.mini.spec.ts
+++ b/spec/modifiers/branded.mini.spec.ts
@@ -1,0 +1,14 @@
+import { z } from 'zod/v4-mini';
+import { expectSchema, registerSchemas } from '../lib/helpers';
+
+describe('zod mini - branded', () => {
+  it('generates OpenAPI schema for branded type', () => {
+    const schema = z.string().brand<'color'>();
+
+    registerSchemas({ SimpleStringBranded: schema });
+
+    expectSchema([schema], {
+      SimpleStringBranded: { type: 'string' },
+    });
+  });
+});

--- a/spec/modifiers/catchall.mini.spec.ts
+++ b/spec/modifiers/catchall.mini.spec.ts
@@ -1,0 +1,77 @@
+import { z } from 'zod/v4-mini';
+import { expectSchema, registerSchemas } from '../lib/helpers';
+
+describe('zod mini - catchall', () => {
+  it('generates an additionalProperties schema for objects with catchall', () => {
+    const schema = z.catchall(z.object({}), z.string());
+
+    registerSchemas({ CatchallObject: schema });
+
+    expectSchema([schema], {
+      CatchallObject: {
+        type: 'object',
+        properties: {},
+        additionalProperties: {
+          type: 'string',
+        },
+      },
+    });
+  });
+
+  it('generates a referenced additionalProperties schema', () => {
+    const fallback = z.string();
+    const schema = z.catchall(z.object({}), fallback);
+
+    registerSchemas({ CatchallObject: schema, SomeString: fallback });
+
+    expectSchema([schema], {
+      SomeString: {
+        type: 'string',
+      },
+      CatchallObject: {
+        type: 'object',
+        properties: {},
+        additionalProperties: {
+          $ref: '#/components/schemas/SomeString',
+        },
+      },
+    });
+  });
+
+  it('can override previous catchalls BUT looses Base reference', () => {
+    const BaseSchema = z.catchall(z.object({ id: z.string() }), z.string());
+    const ExtendedSchema = z.catchall(
+      z.extend(BaseSchema, { bonus: z.number() }),
+      z.union([z.boolean(), z.number(), z.string()])
+    );
+
+    registerSchemas({
+      Base: BaseSchema,
+      Extended: ExtendedSchema,
+    });
+
+    expectSchema([BaseSchema, ExtendedSchema], {
+      Base: {
+        type: 'object',
+        required: ['id'],
+        properties: {
+          id: { type: 'string' },
+        },
+        additionalProperties: {
+          type: 'string',
+        },
+      },
+      Extended: {
+        type: 'object',
+        required: ['id', 'bonus'],
+        properties: {
+          id: { type: 'string' },
+          bonus: { type: 'number' },
+        },
+        additionalProperties: {
+          anyOf: [{ type: 'boolean' }, { type: 'number' }, { type: 'string' }],
+        },
+      },
+    });
+  });
+});

--- a/src/openapi-metadata.ts
+++ b/src/openapi-metadata.ts
@@ -1,6 +1,6 @@
-import { ZodType } from 'zod/v4';
+import { $ZodType } from 'zod/v4/core';
 import { isUndefined, omitBy } from './lib/lodash';
 import { Metadata } from './metadata';
-export function getOpenApiMetadata<T extends ZodType>(zodSchema: T) {
+export function getOpenApiMetadata<T extends $ZodType>(zodSchema: T) {
   return omitBy(Metadata.getOpenApiMetadata(zodSchema) ?? {}, isUndefined);
 }

--- a/src/transformers/array.ts
+++ b/src/transformers/array.ts
@@ -1,28 +1,28 @@
-import { ZodArray } from 'zod/v4';
+import { $ZodArray } from 'zod/v4/core';
 import { MapNullableType, MapSubSchema } from '../types';
 import { $ZodCheckMinLength, $ZodCheckMaxLength } from 'zod/v4/core';
-import { isAnyZodType } from '../lib/zod-is-type';
+import { isAnyCoreZodType } from '../lib/zod-is-type';
 export class ArrayTransformer {
   transform(
-    zodSchema: ZodArray,
+    zodSchema: $ZodArray,
     mapNullableType: MapNullableType,
     mapItems: MapSubSchema
   ) {
-    const itemType = zodSchema.def.element;
+    const itemType = zodSchema._zod.def.element;
 
-    const minItems = zodSchema.def.checks?.find(
+    const minItems = zodSchema._zod.def.checks?.find(
       (check): check is $ZodCheckMinLength =>
         check._zod.def.check === 'min_length'
     )?._zod.def.minimum;
 
-    const maxItems = zodSchema.def.checks?.find(
+    const maxItems = zodSchema._zod.def.checks?.find(
       (check): check is $ZodCheckMaxLength =>
         check._zod.def.check === 'max_length'
     )?._zod.def.maximum;
 
     return {
       ...mapNullableType('array'),
-      items: isAnyZodType(itemType) ? mapItems(itemType) : {},
+      items: isAnyCoreZodType(itemType) ? mapItems(itemType) : {},
 
       minItems,
       maxItems,

--- a/src/transformers/enum.ts
+++ b/src/transformers/enum.ts
@@ -1,10 +1,10 @@
-import { ZodEnum } from 'zod/v4';
+import { $ZodEnum } from 'zod/v4/core';
 import { MapNullableType } from '../types';
 import { enumInfo } from '../lib/enum-info';
 import { ZodToOpenAPIError } from '../errors';
 
 export class EnumTransformer {
-  transform(zodSchema: ZodEnum, mapNullableType: MapNullableType) {
+  transform(zodSchema: $ZodEnum, mapNullableType: MapNullableType) {
     const { type, values } = enumInfo(zodSchema._zod.def.entries);
 
     if (type === 'mixed') {

--- a/src/transformers/index.ts
+++ b/src/transformers/index.ts
@@ -1,5 +1,5 @@
 import { SchemaObject, ReferenceObject, MapSubSchema } from '../types';
-import { ZodType } from 'zod/v4';
+import { $ZodType } from 'zod/v4/core';
 import { UnknownZodTypeError } from '../errors';
 import { isZodType } from '../lib/zod-is-type';
 import { Metadata } from '../metadata';
@@ -38,7 +38,7 @@ export class OpenApiTransformer {
   }
 
   transform<T>(
-    zodSchema: ZodType<T>,
+    zodSchema: $ZodType<T>,
     isNullable: boolean,
     mapItem: MapSubSchema,
     generateSchemaRef: (ref: string) => string,
@@ -72,7 +72,7 @@ export class OpenApiTransformer {
   }
 
   private transformSchemaWithoutDefault(
-    zodSchema: ZodType,
+    zodSchema: $ZodType,
     isNullable: boolean,
     mapItem: MapSubSchema,
     generateSchemaRef: (ref: string) => string
@@ -179,7 +179,7 @@ export class OpenApiTransformer {
     const refId = Metadata.getRefId(zodSchema);
 
     throw new UnknownZodTypeError({
-      currentSchema: zodSchema.def,
+      currentSchema: zodSchema._zod.def,
       schemaName: refId,
     });
   }

--- a/src/transformers/intersection.ts
+++ b/src/transformers/intersection.ts
@@ -3,12 +3,12 @@ import {
   MapSubSchema,
   SchemaObject,
 } from '../types';
-import { ZodIntersection, ZodType } from 'zod/v4';
-import { isAnyZodType, isZodType } from '../lib/zod-is-type';
+import { $ZodIntersection, $ZodType } from 'zod/v4/core';
+import { isAnyCoreZodType, isZodType } from '../lib/zod-is-type';
 
 export class IntersectionTransformer {
   transform(
-    zodSchema: ZodIntersection,
+    zodSchema: $ZodIntersection,
     isNullable: boolean,
     mapNullableOfArray: MapNullableOfArrayWithNullable,
     mapItem: MapSubSchema
@@ -28,15 +28,15 @@ export class IntersectionTransformer {
     return allOfSchema;
   }
 
-  private flattenIntersectionTypes(schema: ZodType): ZodType[] {
+  private flattenIntersectionTypes(schema: $ZodType): $ZodType[] {
     if (!isZodType(schema, 'ZodIntersection')) {
       return [schema];
     }
 
-    const leftSubTypes = isAnyZodType(schema._zod.def.left)
+    const leftSubTypes = isAnyCoreZodType(schema._zod.def.left)
       ? this.flattenIntersectionTypes(schema._zod.def.left)
       : [];
-    const rightSubTypes = isAnyZodType(schema._zod.def.right)
+    const rightSubTypes = isAnyCoreZodType(schema._zod.def.right)
       ? this.flattenIntersectionTypes(schema._zod.def.right)
       : [];
 

--- a/src/transformers/literal.ts
+++ b/src/transformers/literal.ts
@@ -1,12 +1,12 @@
-import { ZodLiteral } from 'zod/v4';
+import { $ZodLiteral } from 'zod/v4/core';
 import { MapNullableType } from '../types';
 import { BigIntTransformer } from './big-int';
 
 export class LiteralTransformer {
   private bigIntTransformer = new BigIntTransformer();
 
-  transform(zodSchema: ZodLiteral, mapNullableType: MapNullableType) {
-    const type = typeof zodSchema.def.values[0];
+  transform(zodSchema: $ZodLiteral, mapNullableType: MapNullableType) {
+    const type = typeof zodSchema._zod.def.values[0];
 
     if (
       type === 'boolean' ||
@@ -16,7 +16,7 @@ export class LiteralTransformer {
     ) {
       return {
         ...mapNullableType(type),
-        enum: [zodSchema.def.values[0]],
+        enum: [zodSchema._zod.def.values[0]],
       };
     }
 

--- a/src/transformers/number.ts
+++ b/src/transformers/number.ts
@@ -1,16 +1,18 @@
-import { ZodNumber } from 'zod/v4';
+import { $ZodNumber } from 'zod/v4/core';
 import { MapNullableType, GetNumberChecks } from '../types';
 
 export class NumberTransformer {
   transform(
-    zodSchema: ZodNumber,
+    zodSchema: $ZodNumber,
     mapNullableType: MapNullableType,
     getNumberChecks: GetNumberChecks
   ) {
     return {
       ...mapNullableType('number'),
-      ...mapNullableType(zodSchema.format === 'safeint' ? 'integer' : 'number'),
-      ...getNumberChecks(zodSchema.def.checks ?? []),
+      ...mapNullableType(
+        zodSchema._zod.bag.format === 'safeint' ? 'integer' : 'number'
+      ),
+      ...getNumberChecks(zodSchema._zod.def.checks ?? []),
     };
   }
 }

--- a/src/transformers/record.ts
+++ b/src/transformers/record.ts
@@ -1,18 +1,18 @@
 import { MapNullableType, MapSubSchema, SchemaObject } from '../types';
-import { ZodRecord } from 'zod/v4';
-import { isAnyZodType, isZodType } from '../lib/zod-is-type';
+import { $ZodRecord } from 'zod/v4/core';
+import { isAnyCoreZodType, isZodType } from '../lib/zod-is-type';
 import { isString } from '../lib/lodash';
 
 export class RecordTransformer {
   transform(
-    zodSchema: ZodRecord,
+    zodSchema: $ZodRecord,
     mapNullableType: MapNullableType,
     mapItem: MapSubSchema
   ): SchemaObject {
-    const propertiesType = zodSchema.valueType;
-    const keyType = zodSchema.keyType;
+    const propertiesType = zodSchema._zod.def.valueType;
+    const keyType = zodSchema._zod.def.keyType;
 
-    const propertiesSchema = isAnyZodType(propertiesType)
+    const propertiesSchema = isAnyCoreZodType(propertiesType)
       ? mapItem(propertiesType)
       : {};
 

--- a/src/transformers/string.ts
+++ b/src/transformers/string.ts
@@ -1,4 +1,4 @@
-import { ZodString } from 'zod/v4';
+import { $ZodString } from 'zod/v4/core';
 import { MapNullableType } from '../types';
 import {
   $ZodCheck,
@@ -21,22 +21,22 @@ function isZodCheckRegex(check: $ZodCheck<string>): check is $ZodCheckRegex {
 }
 
 export class StringTransformer {
-  transform(zodSchema: ZodString, mapNullableType: MapNullableType) {
-    const regexCheck = zodSchema.def.checks?.find(isZodCheckRegex);
+  transform(zodSchema: $ZodString, mapNullableType: MapNullableType) {
+    const regexCheck = zodSchema._zod.def.checks?.find(isZodCheckRegex);
     // toString generates an additional / at the beginning and end of the pattern
     const pattern = regexCheck?._zod.def.pattern
       .toString()
       .replace(/^\/|\/$/g, '');
 
-    const check = zodSchema.def.checks?.find(isZodCheckLengthEquals);
+    const check = zodSchema._zod.def.checks?.find(isZodCheckLengthEquals);
     const length = check?._zod.def.length;
 
-    const maxLength = Number.isFinite(zodSchema.minLength)
-      ? zodSchema.minLength ?? undefined
+    const maxLength = Number.isFinite(zodSchema._zod.bag.minimum)
+      ? zodSchema._zod.bag.minimum ?? undefined
       : undefined;
 
-    const minLength = Number.isFinite(zodSchema.maxLength)
-      ? zodSchema.maxLength ?? undefined
+    const minLength = Number.isFinite(zodSchema._zod.bag.maximum)
+      ? zodSchema._zod.bag.maximum ?? undefined
       : undefined;
 
     return {
@@ -53,18 +53,18 @@ export class StringTransformer {
    * Attempts to map Zod strings to known formats
    * https://json-schema.org/understanding-json-schema/reference/string.html#built-in-formats
    */
-  private mapStringFormat(zodString: ZodString): string | undefined {
-    if (zodString.format === 'uuid') return 'uuid';
-    if (zodString.format === 'email') return 'email';
-    if (zodString.format === 'url') return 'uri';
-    if (zodString.format === 'date') return 'date';
-    if (zodString.format === 'datetime') return 'date-time';
-    if (zodString.format === 'cuid') return 'cuid';
-    if (zodString.format === 'cuid2') return 'cuid2';
-    if (zodString.format === 'ulid') return 'ulid';
-    if (zodString.format === 'ipv4') return 'ip';
-    if (zodString.format === 'ipv6') return 'ip';
-    if (zodString.format === 'emoji') return 'emoji';
+  private mapStringFormat(zodString: $ZodString): string | undefined {
+    if (zodString._zod.bag.format === 'uuid') return 'uuid';
+    if (zodString._zod.bag.format === 'email') return 'email';
+    if (zodString._zod.bag.format === 'url') return 'uri';
+    if (zodString._zod.bag.format === 'date') return 'date';
+    if (zodString._zod.bag.format === 'datetime') return 'date-time';
+    if (zodString._zod.bag.format === 'cuid') return 'cuid';
+    if (zodString._zod.bag.format === 'cuid2') return 'cuid2';
+    if (zodString._zod.bag.format === 'ulid') return 'ulid';
+    if (zodString._zod.bag.format === 'ipv4') return 'ip';
+    if (zodString._zod.bag.format === 'ipv6') return 'ip';
+    if (zodString._zod.bag.format === 'emoji') return 'emoji';
 
     return undefined;
   }

--- a/src/transformers/tuple.ts
+++ b/src/transformers/tuple.ts
@@ -1,20 +1,20 @@
 import { MapNullableType, MapSubSchema, SchemaObject } from '../types';
-import { ZodTuple } from 'zod/v4';
+import { $ZodTuple } from 'zod/v4/core';
 import { OpenApiVersionSpecifics } from '../openapi-generator';
-import { isAnyZodType } from '../lib/zod-is-type';
+import { isAnyCoreZodType } from '../lib/zod-is-type';
 
 export class TupleTransformer {
   constructor(private versionSpecifics: OpenApiVersionSpecifics) {}
 
   transform(
-    zodSchema: ZodTuple,
+    zodSchema: $ZodTuple,
     mapNullableType: MapNullableType,
     mapItem: MapSubSchema
   ): SchemaObject {
     const items = zodSchema._zod.def.items;
 
     const schemas = items.map(item =>
-      isAnyZodType(item) ? mapItem(item) : {}
+      isAnyCoreZodType(item) ? mapItem(item) : {}
     );
 
     return {

--- a/src/transformers/union.ts
+++ b/src/transformers/union.ts
@@ -1,10 +1,10 @@
-import { ZodType, ZodUnion } from 'zod/v4';
+import { $ZodType, $ZodUnion } from 'zod/v4/core';
 import { MapNullableOfArray, MapSubSchema } from '../types';
-import { isAnyZodType, isZodType } from '../lib/zod-is-type';
+import { isAnyCoreZodType, isZodType } from '../lib/zod-is-type';
 
 export class UnionTransformer {
   transform(
-    zodSchema: ZodUnion,
+    zodSchema: $ZodUnion,
     mapNullableOfArray: MapNullableOfArray,
     mapItem: MapSubSchema
   ) {
@@ -25,22 +25,22 @@ export class UnionTransformer {
     };
   }
 
-  private flattenUnionTypes(schema: ZodType): ZodType[] {
+  private flattenUnionTypes(schema: $ZodType): $ZodType[] {
     if (!isZodType(schema, 'ZodUnion')) {
       return [schema];
     }
 
-    const options = schema.def.options;
+    const options = schema._zod.def.options;
 
     return options.flatMap(option =>
-      isAnyZodType(option) ? this.flattenUnionTypes(option) : []
+      isAnyCoreZodType(option) ? this.flattenUnionTypes(option) : []
     );
   }
 
-  private unwrapNullable(schema: ZodType): ZodType {
+  private unwrapNullable(schema: $ZodType): $ZodType {
     if (isZodType(schema, 'ZodNullable')) {
-      const unwrapped = schema.unwrap();
-      if (isAnyZodType(unwrapped)) {
+      const unwrapped = schema._zod.def.innerType;
+      if (isAnyCoreZodType(unwrapped)) {
         return this.unwrapNullable(unwrapped);
       }
     }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-import type { ZodType } from 'zod/v4';
+import type { $ZodType } from 'zod/v4/core';
 import type { $ZodCheck } from 'zod/v4/core';
 import type {
   ReferenceObject as ReferenceObject30,
@@ -73,5 +73,5 @@ export type GetNumberChecks = (
 >;
 
 export type MapSubSchema = (
-  zodSchema: ZodType
+  zodSchema: $ZodType
 ) => SchemaObject | ReferenceObject;

--- a/src/v3.0/openapi-generator.ts
+++ b/src/v3.0/openapi-generator.ts
@@ -1,9 +1,9 @@
 import type { OpenAPIObject } from 'openapi3-ts/oas30';
 
-import { OpenAPIGenerator, OpenApiVersion } from '../openapi-generator';
-import { ZodSchema } from 'zod/v4';
+import { OpenAPIGenerator } from '../openapi-generator';
 import { OpenApiGeneratorV30Specifics } from './specifics';
 import { OpenAPIDefinitions } from '../openapi-registry';
+import type { $ZodType } from 'zod/v4/core';
 
 export type OpenAPIObjectConfig = Omit<
   OpenAPIObject,
@@ -13,7 +13,7 @@ export type OpenAPIObjectConfig = Omit<
 export class OpenApiGeneratorV3 {
   private generator;
 
-  constructor(definitions: (OpenAPIDefinitions | ZodSchema)[]) {
+  constructor(definitions: (OpenAPIDefinitions | $ZodType)[]) {
     const specifics = new OpenApiGeneratorV30Specifics();
     this.generator = new OpenAPIGenerator(definitions, specifics);
   }

--- a/src/v3.1/openapi-generator.ts
+++ b/src/v3.1/openapi-generator.ts
@@ -1,7 +1,7 @@
 import type { OpenAPIObject, PathItemObject } from 'openapi3-ts/oas31';
 
-import { OpenAPIGenerator, OpenApiVersion } from '../openapi-generator';
-import { ZodSchema } from 'zod/v4';
+import { OpenAPIGenerator } from '../openapi-generator';
+import { $ZodType } from 'zod/v4/core';
 import { OpenApiGeneratorV31Specifics } from './specifics';
 import {
   OpenAPIDefinitions,
@@ -10,7 +10,7 @@ import {
 } from '../openapi-registry';
 
 function isWebhookDefinition(
-  definition: OpenAPIDefinitions | ZodSchema
+  definition: OpenAPIDefinitions | $ZodType
 ): definition is WebhookDefinition {
   return 'type' in definition && definition.type === 'webhook';
 }
@@ -24,7 +24,7 @@ export class OpenApiGeneratorV31 {
   private generator;
   private webhookRefs: Record<string, PathItemObject> = {};
 
-  constructor(private definitions: (OpenAPIDefinitions | ZodSchema)[]) {
+  constructor(private definitions: (OpenAPIDefinitions | $ZodType)[]) {
     const specifics = new OpenApiGeneratorV31Specifics();
     this.generator = new OpenAPIGenerator(this.definitions, specifics);
   }


### PR DESCRIPTION
This PR try to support zod-mini by using `zod/v4/core` as recommended in [Official Zod Guide](https://zod.dev/library-authors?id=how-to-support-zod-and-zod-mini-simultaneously).

In the process of adding support, I am mainly facing issue on how to replace the `.openapi` extension. 

Ideally we could make it work without extension. I think this can be achieved by using the `OpenAPIRegistry.register` adding the optional `metadata` in addition to `refId`.
