### PR TITLE
allow numbers as status codes in responses

### DIFF
--- a/src/openapi-registry.ts
+++ b/src/openapi-registry.ts
@@ -107,6 +107,8 @@ type ZodObjectWithEffect = ZodObject | ZodPipe;
 
 export type RouteParameter = ZodObjectWithEffect | undefined;
 
+export type StatusCode = string | number;
+
 export type RouteConfig = Omit<OperationObject, 'responses'> & {
   method: Method;
   path: string;
@@ -118,7 +120,7 @@ export type RouteConfig = Omit<OperationObject, 'responses'> & {
     headers?: RouteParameter | ZodType<unknown>[];
   };
   responses: {
-    [statusCode: string]: ResponseConfig | ReferenceObject;
+    [statusCode: StatusCode]: ResponseConfig | ReferenceObject;
   };
 };
 


### PR DESCRIPTION
Although this is not a problem in the regular format, when trying to create custom types based on the `RouteConfig` type. I cannot set the status code to a number.

for example creating the custom type
```ts
type KeyValueUnion<T> = {
  [K in keyof T]: { status: K, result: T[K] }
}[keyof T];

type IRoute<I = RouteConfig['request'], O = RouteConfig['responses']> = Omit<RouteConfig, 'request' | 'responses'> & {
  request: I,
  responses: O,

  func: (input: I) => Promise<KeyValueUnion<O>>
}
```

For easier integration with express, It wants the status code to be a string. (as now I don't use the status code as a key to an object, but as a value of an object)