### PR TITLE
change OpenApiOptions from interface to type

### DIFF
--- a/src/zod-extensions.ts
+++ b/src/zod-extensions.ts
@@ -30,7 +30,7 @@ export type ZodOpenAPIMetadata<T = any, E = ExampleValue<T>> = Omit<
   _internal?: never;
 };
 
-interface OpenApiOptions {
+type OpenApiOptions = {
   unionPreferredType?: UnionPreferredType;
 }
 


### PR DESCRIPTION
**Why?**

Because extending an object throws TS4023 when OpenApiOptions is declared as an interface.

```ts
//           Exported variable 'schema' has or is using name 'OpenApiOptions'
//           from external module "/node_modules/@asteasolutions/zod-to-openapi/
//           dist/zod-extendsions" but cannot be named. (ts4023)
//             |
//             V
export const schema = z.object({ 
//           ~~~~~~
    // anything
})
.extend(z.object({
    // anything
}));

``` 

**Why does using a type work?**
Not sure, see [here](https://stackoverflow.com/a/69870219). But it does and using a type instead of an interface does no harm.

**Potential workaround**
One could use the deprecated `.merge` but it is not the same as `.extend`, for example `.extend` supports `ZodUnion`.  So for now I actually patch this in our project.