### PR TITLE
fix: add null option for nullable enum

### DIFF
--- a/spec/types/enum.spec.ts
+++ b/spec/types/enum.spec.ts
@@ -15,4 +15,20 @@ describe('enum', () => {
       },
     });
   });
+
+  it('supports nullable enums', () => {
+    const schema = z
+      .enum(['option1', 'option2'])
+      .nullable()
+      .openapi('Enum', { description: 'All possible options' });
+
+    expectSchema([schema], {
+      Enum: {
+        type: 'string',
+        nullable: true,
+        description: 'All possible options',
+        enum: ['option1', 'option2', null],
+      },
+    });
+  });
 });

--- a/src/transformers/enum.ts
+++ b/src/transformers/enum.ts
@@ -4,7 +4,11 @@ import { enumInfo } from '../lib/enum-info';
 import { ZodToOpenAPIError } from '../errors';
 
 export class EnumTransformer {
-  transform(zodSchema: ZodEnum, mapNullableType: MapNullableType) {
+  transform(
+    zodSchema: ZodEnum,
+    isNullable: boolean,
+    mapNullableType: MapNullableType
+  ) {
     const { type, values } = enumInfo(zodSchema._zod.def.entries);
 
     if (type === 'mixed') {
@@ -23,7 +27,7 @@ export class EnumTransformer {
 
     return {
       ...mapNullableType(type === 'numeric' ? 'integer' : 'string'),
-      enum: values,
+      enum: isNullable ? [...values, null] : values,
     };
   }
 }

--- a/src/transformers/index.ts
+++ b/src/transformers/index.ts
@@ -119,7 +119,7 @@ export class OpenApiTransformer {
     }
 
     if (isZodType(zodSchema, 'ZodEnum')) {
-      return this.enumTransformer.transform(zodSchema, schema =>
+      return this.enumTransformer.transform(zodSchema, isNullable, schema =>
         this.versionSpecifics.mapNullableType(schema, isNullable)
       );
     }


### PR DESCRIPTION
Ref: 
- https://swagger.io/docs/specification/v3_0/data-models/enums/
- https://github.com/OAI/OpenAPI-Specification/blob/main/proposals/2019-10-31-Clarify-Nullable.md#if-a-schema-specifies-nullable-true-and-enum-1-2-3-does-that-schema-allow-null-values-see-1900