### PR TITLE
feat: add `void` & `never` support

### DIFF
--- a/spec/types/never.spec.ts
+++ b/spec/types/never.spec.ts
@@ -1,0 +1,144 @@
+import { z } from 'zod';
+import { expectSchema } from '../lib/helpers';
+
+describe('never', () => {
+  describe('in object properties', () => {
+    it('skips never properties in objects', () => {
+      const schema = z
+        .object({
+          id: z.string(),
+          impossible: z.never(),
+          name: z.string(),
+        })
+        .openapi('TestObject');
+
+      expectSchema([schema], {
+        TestObject: {
+          type: 'object',
+          properties: {
+            id: {
+              type: 'string',
+            },
+            name: {
+              type: 'string',
+            },
+          },
+          required: ['id', 'name'],
+        },
+      });
+    });
+
+    it('does not mark never as required', () => {
+      const schema = z
+        .object({
+          id: z.string(),
+          impossible: z.never(),
+        })
+        .openapi('TestObject');
+
+      expectSchema([schema], {
+        TestObject: {
+          type: 'object',
+          properties: {
+            id: {
+              type: 'string',
+            },
+          },
+          required: ['id'],
+        },
+      });
+    });
+
+    it('skips optional never properties', () => {
+      const schema = z
+        .object({
+          id: z.string(),
+          impossible: z.never().optional(),
+        })
+        .openapi('TestObject');
+
+      expectSchema([schema], {
+        TestObject: {
+          type: 'object',
+          properties: {
+            id: {
+              type: 'string',
+            },
+          },
+          required: ['id'],
+        },
+      });
+    });
+  });
+
+  describe('as direct schema', () => {
+    it('allows z.never() as direct schema - returns empty schema', () => {
+      const schema = z.never().openapi('DirectNever');
+
+      expectSchema([schema], {
+        DirectNever: {},
+      });
+    });
+
+    it('returns empty schema for optional never at top level', () => {
+      const schema = z.never().optional().openapi('OptionalNever');
+
+      expectSchema([schema], {
+        OptionalNever: {},
+      });
+    });
+
+    it('returns empty schema for nullable never at top level', () => {
+      const schema = z.never().nullable().openapi('NullableNever');
+
+      expectSchema([schema], {
+        NullableNever: {},
+      });
+    });
+  });
+
+  describe('in arrays', () => {
+    it('allows z.never() in array - returns array with no items constraint', () => {
+      const schema = z.array(z.never()).openapi('NeverArray');
+
+      expectSchema([schema], {
+        NeverArray: {
+          type: 'array',
+          items: {},
+        },
+      });
+    });
+  });
+
+  describe('in unions', () => {
+    it('filters never from union - only keeps non-never types', () => {
+      const schema = z.union([z.string(), z.never()]).openapi('StringOrNever');
+
+      expectSchema([schema], {
+        StringOrNever: {
+          type: 'string',
+        },
+      });
+    });
+
+    it('filters never from union with multiple types', () => {
+      const schema = z
+        .union([z.string(), z.number(), z.never()])
+        .openapi('StringNumberOrNever');
+
+      expectSchema([schema], {
+        StringNumberOrNever: {
+          anyOf: [{ type: 'string' }, { type: 'number' }],
+        },
+      });
+    });
+
+    it('returns empty schema for union with only never types', () => {
+      const schema = z.union([z.never(), z.never()]).openapi('OnlyNever');
+
+      expectSchema([schema], {
+        OnlyNever: {},
+      });
+    });
+  });
+});

--- a/spec/types/void.spec.ts
+++ b/spec/types/void.spec.ts
@@ -1,0 +1,146 @@
+import { z } from 'zod';
+import { expectSchema } from '../lib/helpers';
+
+describe('void', () => {
+  describe('in object properties', () => {
+    it('skips void properties in objects', () => {
+      const schema = z
+        .object({
+          id: z.string(),
+          unused: z.void(),
+          name: z.string(),
+        })
+        .openapi('TestObject');
+
+      expectSchema([schema], {
+        TestObject: {
+          type: 'object',
+          properties: {
+            id: {
+              type: 'string',
+            },
+            name: {
+              type: 'string',
+            },
+          },
+          required: ['id', 'name'],
+        },
+      });
+    });
+
+    it('does not mark void as required', () => {
+      const schema = z
+        .object({
+          id: z.string(),
+          unused: z.void(),
+        })
+        .openapi('TestObject');
+
+      expectSchema([schema], {
+        TestObject: {
+          type: 'object',
+          properties: {
+            id: {
+              type: 'string',
+            },
+          },
+          required: ['id'],
+        },
+      });
+    });
+
+    it('skips optional void properties', () => {
+      const schema = z
+        .object({
+          id: z.string(),
+          unused: z.void().optional(),
+        })
+        .openapi('TestObject');
+
+      expectSchema([schema], {
+        TestObject: {
+          type: 'object',
+          properties: {
+            id: {
+              type: 'string',
+            },
+          },
+          required: ['id'],
+        },
+      });
+    });
+  });
+
+  describe('as direct schema', () => {
+    it('allows z.void() as direct schema - returns empty schema', () => {
+      const schema = z.void().openapi('DirectVoid');
+
+      expectSchema([schema], {
+        DirectVoid: {},
+      });
+    });
+
+    it('returns empty schema for optional void at top level', () => {
+      const schema = z.void().optional().openapi('OptionalVoid');
+
+      expectSchema([schema], {
+        OptionalVoid: {},
+      });
+    });
+
+    it('returns empty schema for nullable void at top level', () => {
+      const schema = z.void().nullable().openapi('NullableVoid');
+
+      expectSchema([schema], {
+        NullableVoid: {},
+      });
+    });
+  });
+
+  describe('in arrays', () => {
+    it('allows z.void() in array - returns array with no items constraint', () => {
+      const schema = z.array(z.void()).openapi('VoidArray');
+
+      expectSchema([schema], {
+        VoidArray: {
+          type: 'array',
+          items: {},
+        },
+      });
+    });
+  });
+
+  describe('in unions', () => {
+    it('filters void from union - only keeps non-void types', () => {
+      const schema = z.union([z.string(), z.void()]).openapi('StringOrVoid');
+
+      expectSchema([schema], {
+        StringOrVoid: {
+          type: 'string',
+        },
+      });
+    });
+
+    it('filters void from union with multiple types', () => {
+      const schema = z
+        .union([z.string(), z.number(), z.void()])
+        .openapi('StringNumberOrVoid');
+
+      expectSchema([schema], {
+        StringNumberOrVoid: {
+          anyOf: [{ type: 'string' }, { type: 'number' }],
+        },
+      });
+    });
+
+    it('returns empty schema for union with only void types', () => {
+      const schema = z.union([z.void(), z.void()]).openapi('OnlyVoid');
+
+      expectSchema([schema], {
+        OnlyVoid: {},
+      });
+    });
+  });
+});
+
+

--- a/src/lib/zod-is-type.ts
+++ b/src/lib/zod-is-type.ts
@@ -94,6 +94,13 @@ export function isAnyZodType(schema: object): schema is z.ZodType {
 }
 
 /**
+ * Checks if a schema is void or never, which should be skipped
+ * since they don't contribute meaningful OpenAPI constraints
+ */
+export function isSkippableZodType(schema: z.ZodType): boolean {
+  return isZodType(schema, ['ZodVoid', 'ZodNever']);
+}
+/**
  * The schema.isNullable() is deprecated. This is the suggested replacement
  * as this was how isNullable operated beforehand.
  */

--- a/src/transformers/array.ts
+++ b/src/transformers/array.ts
@@ -1,7 +1,8 @@
 import { ZodArray } from 'zod';
 import { MapNullableType, MapSubSchema } from '../types';
 import { $ZodCheckMinLength, $ZodCheckMaxLength } from 'zod/core';
-import { isAnyZodType } from '../lib/zod-is-type';
+import { isAnyZodType, isSkippableZodType } from '../lib/zod-is-type';
+
 export class ArrayTransformer {
   transform(
     zodSchema: ZodArray,
@@ -22,7 +23,10 @@ export class ArrayTransformer {
 
     return {
       ...mapNullableType('array'),
-      items: isAnyZodType(itemType) ? mapItems(itemType) : {},
+      items:
+        isAnyZodType(itemType) && !isSkippableZodType(zodSchema)
+          ? mapItems(itemType)
+          : {},
 
       minItems,
       maxItems,

--- a/src/transformers/index.ts
+++ b/src/transformers/index.ts
@@ -1,7 +1,7 @@
 import { SchemaObject, ReferenceObject, MapSubSchema } from '../types';
 import { ZodType } from 'zod';
 import { UnknownZodTypeError } from '../errors';
-import { isZodType } from '../lib/zod-is-type';
+import { isSkippableZodType, isZodType } from '../lib/zod-is-type';
 import { Metadata } from '../metadata';
 import { ArrayTransformer } from './array';
 import { BigIntTransformer } from './big-int';
@@ -51,6 +51,10 @@ export class OpenApiTransformer {
     generateSchemaRef: (ref: string) => string,
     defaultValue?: T
   ): SchemaObject | ReferenceObject {
+    if (isSkippableZodType(zodSchema)) {
+      return {};
+    }
+
     if (isZodType(zodSchema, 'ZodNull')) {
       return this.versionSpecifics.nullType;
     }


### PR DESCRIPTION
Currently, `void` and `never` are failing with the following error:

```
UnknownZodTypeError {
  message: 'Unknown zod object type, please specify `type` and other OpenAPI props using `schema.openapi`.',
  data: {
    currentSchema: { type: 'never', error: [Function: error] },
    schemaName: undefined
  }
}
```

This was brought up in #290, although the closure felt a little premature: https://github.com/asteasolutions/zod-to-openapi/issues/290#issuecomment-2646129379.

> There isn't really anything that we can translate this to in terms of "open api specification"

I'm completely in support of this idea, although would advocate for the library gracefully handling these instead of erroring out. This is what this PR attempts to do. After all, if OpenAPI is meant to express what _should_ be in the request, what _shouldn't_ be in there has no relevance!

**AI Disclosure**: I used copilot to generate an initial plan and framework, particularly for the tests. All code was subsequently personally reviewed and edited.