### PR TITLE
Support `z.guid()` as a string format

### DIFF
--- a/src/transformers/string.ts
+++ b/src/transformers/string.ts
@@ -54,6 +54,7 @@ export class StringTransformer {
    * https://json-schema.org/understanding-json-schema/reference/string.html#built-in-formats
    */
   private mapStringFormat(zodString: ZodString): string | undefined {
+    if (zodString.format === 'guid') return 'guid';
     if (zodString.format === 'uuid') return 'uuid';
     if (zodString.format === 'email') return 'email';
     if (zodString.format === 'url') return 'uri';


### PR DESCRIPTION
This PR adds support for `z.guid()` as a string format, removing the need for custom types.

https://zod.dev/api?id=uuids