### PR TITLE
feat: support zodv4 prefault new type

### DIFF
--- a/README.md
+++ b/README.md
@@ -630,6 +630,7 @@ The list of all supported types as of now is:
 - `ZodBoolean`
 - `ZodDate`
 - `ZodDefault`
+- `ZodPrefault`
 - `ZodDiscriminatedUnion`
   - including `discriminator` mapping when all Zod objects in the union are registered with `.register()` or contain a `refId`.
 - `ZodEffects`

--- a/spec/modifiers/prefault.spec.ts
+++ b/spec/modifiers/prefault.spec.ts
@@ -1,0 +1,44 @@
+import { z } from 'zod';
+import { expectSchema } from '../lib/helpers';
+
+describe('prefault', () => {
+  it('supports prefault values', () => {
+    const schema = z
+      .string()
+      .prefault('prefaulted')
+      .openapi('StringWithPrefault');
+
+    expectSchema([schema], {
+      StringWithPrefault: {
+        type: 'string',
+        default: 'prefaulted',
+      },
+    });
+  });
+
+  it('supports default overriding prefault for openapi default', () => {
+    const schema = z
+      .string()
+      .default('defaulted')
+      .prefault('prefaulted')
+      .openapi('StringWithPrefaultAndDefault');
+
+    expectSchema([schema], {
+      StringWithPrefaultAndDefault: {
+        type: 'string',
+        default: 'defaulted',
+      },
+    });
+  });
+
+  it('supports default when prefault is not present', () => {
+    const schema = z.string().default('defaulted').openapi('StringWithDefault');
+
+    expectSchema([schema], {
+      StringWithDefault: {
+        type: 'string',
+        default: 'defaulted',
+      },
+    });
+  });
+});

--- a/src/lib/zod-is-type.ts
+++ b/src/lib/zod-is-type.ts
@@ -6,6 +6,7 @@ export type ZodTypes = {
   ZodBigInt: z.ZodBigInt;
   ZodBoolean: z.ZodBoolean;
   ZodDefault: z.ZodDefault;
+  ZodPrefault: z.ZodPrefault;
   ZodTransform: z.ZodTransform;
   ZodEnum: z.ZodEnum;
   ZodIntersection: z.ZodIntersection;
@@ -36,6 +37,7 @@ const ZodTypeKeys: Record<keyof ZodTypes, string> = {
   ZodBigInt: 'bigint',
   ZodBoolean: 'boolean',
   ZodDefault: 'default',
+  ZodPrefault: 'prefault',
   ZodTransform: 'transform',
   ZodEnum: 'enum',
   ZodIntersection: 'intersection',

--- a/src/metadata.ts
+++ b/src/metadata.ts
@@ -45,6 +45,7 @@ export class Metadata {
         'ZodOptional',
         'ZodNullable',
         'ZodDefault',
+        'ZodPrefault',
         'ZodReadonly',
         'ZodNonOptional',
       ]) &&
@@ -143,7 +144,9 @@ export class Metadata {
   }
 
   static getDefaultValue<T>(zodSchema: ZodType): T | undefined {
-    const unwrapped = this.unwrapUntil(zodSchema, 'ZodDefault');
+    const unwrapped =
+      this.unwrapUntil(zodSchema, 'ZodDefault') ??
+      this.unwrapUntil(zodSchema, 'ZodPrefault');
 
     return unwrapped?._zod.def.defaultValue as T | undefined;
   }
@@ -166,6 +169,7 @@ export class Metadata {
         'ZodOptional',
         'ZodNullable',
         'ZodDefault',
+        'ZodPrefault',
         'ZodReadonly',
         'ZodNonOptional',
       ]) &&


### PR DESCRIPTION
**Context:**


Zod 4 [introduced `.prefault()`](https://zod.dev/api?id=prefaults) to replicate Zod 3's `.default()` behavior, where the default value is passed *into* the parser (e.g. for transforms), whereas the new `.default()` short-circuits and returns the value directly.

Since OpenAPI has no concept of "pre-parse" vs "short-circuit" defaults (it only has a single `default` field for missing values), this PR maps both Zod concepts to the OpenAPI `default` field.

**This PR includes:**

support for Zod 4's new `prefault` type, and ensures that the default value is correctly extracts regardless of which method is used, prioritizing `.default()` to match runtime precedence:

1.  **`src/lib/zod-is-type.ts`**:
    *   Added `ZodPrefault` to `ZodTypes` and `ZodTypeKeys` definitions.
    *   Ensured `ZodPrefault` is recognized as a distinct Zod type by the internal type checking logic.
2.  **`src/metadata.ts`**:
    *   Updated schema traversal logic (`collectMetadata`, `unwrapUntil`) to handle `ZodPrefault` wrappers, preventing metadata loss when `prefault()` is used.
    *   Updated `getDefaultValue` to support `prefault` values as a fallback for the OpenAPI `default` field.
        *   **Precedence:** `ZodDefault` is checked first. In Zod 4, `.default()` short-circuits the parsing process and returns the value directly if the input is `undefined`.
        *   **Fallback:** If no `ZodDefault` is found, `ZodPrefault` is used. `prefault` ("pre-parse default") passes the default value *into* the schema parsing logic _(replicating Zod 3's default behavior)_.


related issue https://github.com/asteasolutions/zod-to-openapi/issues/327
