### PR TITLE
fix: allow nested discriminated unions as they are supported in Zod v4

### DIFF
--- a/spec/types/discriminated-union.spec.ts
+++ b/spec/types/discriminated-union.spec.ts
@@ -251,4 +251,102 @@ describe('discriminated union', () => {
       },
     });
   });
+
+  it('supports nested discriminated unions', () => {
+    const Circle = z
+      .object({
+        type: z.literal('circle'),
+        radius: z.number(),
+      })
+      .openapi('Circle');
+
+    const Rectangle = z
+      .discriminatedUnion('kind', [
+        z.object({
+          type: z.literal('rectangle'),
+          kind: z.literal('filled'),
+          color: z.string(),
+        }),
+        z.object({
+          type: z.literal('rectangle'),
+          kind: z.literal('outlined'),
+          borderWidth: z.number(),
+        }),
+      ])
+      .openapi('Rectangle');
+
+    expectSchema(
+      [z.discriminatedUnion('type', [Circle, Rectangle]).openapi('Shape')],
+      {
+        Shape: {
+          discriminator: {
+            mapping: {
+              circle: '#/components/schemas/Circle',
+              undefined: '#/components/schemas/Rectangle',
+            },
+            propertyName: 'type',
+          },
+          oneOf: [
+            {
+              $ref: '#/components/schemas/Circle',
+            },
+            {
+              $ref: '#/components/schemas/Rectangle',
+            },
+          ],
+        },
+        Circle: {
+          properties: {
+            radius: {
+              type: 'number',
+            },
+            type: {
+              enum: ['circle'],
+              type: 'string',
+            },
+          },
+          required: ['type', 'radius'],
+          type: 'object',
+        },
+        Rectangle: {
+          oneOf: [
+            {
+              properties: {
+                color: {
+                  type: 'string',
+                },
+                kind: {
+                  enum: ['filled'],
+                  type: 'string',
+                },
+                type: {
+                  enum: ['rectangle'],
+                  type: 'string',
+                },
+              },
+              required: ['type', 'kind', 'color'],
+              type: 'object',
+            },
+            {
+              properties: {
+                borderWidth: {
+                  type: 'number',
+                },
+                kind: {
+                  enum: ['outlined'],
+                  type: 'string',
+                },
+                type: {
+                  enum: ['rectangle'],
+                  type: 'string',
+                },
+              },
+              required: ['type', 'kind', 'borderWidth'],
+              type: 'object',
+            },
+          ],
+        },
+      }
+    );
+  });
 });

--- a/src/transformers/discriminated-union.ts
+++ b/src/transformers/discriminated-union.ts
@@ -77,13 +77,6 @@ export class DiscriminatedUnionTransformer {
 
       const literalValue = value?.def.values[0];
 
-      // This should never happen because Zod checks the disciminator type but to keep the types happy
-      if (typeof literalValue !== 'string') {
-        throw new Error(
-          `Discriminator ${discriminator} could not be found in one of the values of a discriminated union`
-        );
-      }
-
       mapping[literalValue] = generateSchemaRef(refId);
     });
 


### PR DESCRIPTION
Fixed https://github.com/asteasolutions/zod-to-openapi/issues/239.

I marked it as a fix rather than a feature, as I would consider this [expected behavior with Zod v4](https://github.com/colinhacks/zod/issues/1618#issuecomment-3144618640), also didn't have to add additional logic other than removing an error message 🎉 