### PR TITLE
Support sibling metadata on referenced schemas in OpenAPI 3.1

### DIFF
--- a/spec/metadata-overrides.spec.ts
+++ b/spec/metadata-overrides.spec.ts
@@ -137,6 +137,49 @@ describe('metadata overrides', () => {
     );
   });
 
+  it('preserves base component metadata when wrapped ref overrides use OpenAPI 3.0', () => {
+    const ProfileSchema = z
+      .object({
+        name: z.string(),
+      })
+      .openapi('Profile');
+
+    const TestSchema = z
+      .object({
+        key: ProfileSchema.openapi({
+          description: 'field-level description',
+        }).nullable(),
+      })
+      .openapi('Test');
+
+    expectSchema([ProfileSchema, TestSchema], {
+      Profile: {
+        type: 'object',
+        properties: {
+          name: {
+            type: 'string',
+          },
+        },
+        required: ['name'],
+      },
+      Test: {
+        type: 'object',
+        properties: {
+          key: {
+            allOf: [
+              { $ref: '#/components/schemas/Profile' },
+              {
+                nullable: true,
+                description: 'field-level description',
+              },
+            ],
+          },
+        },
+        required: ['key'],
+      },
+    });
+  });
+
   it('only adds overrides for new metadata properties', () => {
     const StringSchema = z.string().openapi('String', {
       description: 'old field',

--- a/spec/metadata-overrides.spec.ts
+++ b/spec/metadata-overrides.spec.ts
@@ -94,6 +94,49 @@ describe('metadata overrides', () => {
     );
   });
 
+  it('preserves base component metadata when ref overrides are wrapped', () => {
+    const ProfileSchema = z
+      .object({
+        name: z.string(),
+      })
+      .openapi('Profile');
+
+    const TestSchema = z
+      .object({
+        key: ProfileSchema.openapi({
+          description: 'field-level description',
+        }).nullable(),
+      })
+      .openapi('Test');
+
+    expectSchema(
+      [ProfileSchema, TestSchema],
+      {
+        Profile: {
+          type: 'object',
+          properties: {
+            name: {
+              type: 'string',
+            },
+          },
+          required: ['name'],
+        },
+        Test: {
+          type: 'object',
+          properties: {
+            key: {
+              $ref: '#/components/schemas/Profile',
+              description: 'field-level description',
+              type: ['object', 'null'],
+            },
+          },
+          required: ['key'],
+        },
+      },
+      { version: '3.1.0' }
+    );
+  });
+
   it('only adds overrides for new metadata properties', () => {
     const StringSchema = z.string().openapi('String', {
       description: 'old field',

--- a/spec/metadata-overrides.spec.ts
+++ b/spec/metadata-overrides.spec.ts
@@ -63,6 +63,37 @@ describe('metadata overrides', () => {
     });
   });
 
+  it('emits sibling metadata for referenced schemas in OpenAPI 3.1', () => {
+    const StringSchema = z.string().openapi('String');
+
+    const TestSchema = z
+      .object({
+        key: StringSchema.openapi({ example: 'test', deprecated: true }),
+      })
+      .openapi('Test');
+
+    expectSchema(
+      [StringSchema, TestSchema],
+      {
+        String: {
+          type: 'string',
+        },
+        Test: {
+          type: 'object',
+          properties: {
+            key: {
+              $ref: '#/components/schemas/String',
+              example: 'test',
+              deprecated: true,
+            },
+          },
+          required: ['key'],
+        },
+      },
+      { version: '3.1.0' }
+    );
+  });
+
   it('only adds overrides for new metadata properties', () => {
     const StringSchema = z.string().openapi('String', {
       description: 'old field',

--- a/spec/modifiers/nullable.spec.ts
+++ b/spec/modifiers/nullable.spec.ts
@@ -83,10 +83,8 @@ describe('nullable', () => {
           type: 'object',
           properties: {
             key: {
-              allOf: [
-                { $ref: '#/components/schemas/String' },
-                { type: ['string', 'null'] },
-              ],
+              $ref: '#/components/schemas/String',
+              type: ['string', 'null'],
             },
           },
           required: ['key'],
@@ -184,15 +182,9 @@ describe('nullable', () => {
           required: ['key'],
           properties: {
             key: {
-              allOf: [
-                {
-                  $ref: '#/components/schemas/Empty',
-                },
-                {
-                  type: ['object', 'null'],
-                  deprecated: true,
-                },
-              ],
+              $ref: '#/components/schemas/Empty',
+              type: ['object', 'null'],
+              deprecated: true,
             },
           },
         },

--- a/spec/routes/index.spec.ts
+++ b/spec/routes/index.spec.ts
@@ -8,6 +8,7 @@ import {
   generateDataForRoute,
   testDocConfig,
 } from '../lib/helpers';
+import { OpenApiGeneratorV3 } from '../../src/v3.0/openapi-generator';
 import { OpenApiGeneratorV31 } from '../../src/v3.1/openapi-generator';
 
 // We need OpenAPIObject31 because of the webhooks property.
@@ -19,6 +20,10 @@ function generateDocumentWithPossibleWebhooks(
     ...testDocConfig,
     openapi: '3.1.0',
   });
+}
+
+function generateDocumentV30(definitions: (OpenAPIDefinitions | ZodType)[]) {
+  return new OpenApiGeneratorV3(definitions).generateDocument(testDocConfig);
 }
 
 const routeTests = ({
@@ -250,6 +255,56 @@ const routeTests = ({
       expect(response).toEqual({
         schema: {
           $ref: '#/components/schemas/Person',
+        },
+      });
+    });
+
+    it('does not emit generated encoding for response content', () => {
+      const registry = new OpenAPIRegistry();
+
+      const Profile = z
+        .object({
+          name: z.string(),
+        })
+        .openapi('Profile');
+
+      registry[registerFunction]({
+        method: 'get',
+        path: '/',
+        responses: {
+          200: {
+            description: 'Simple response',
+            content: {
+              'application/json': {
+                schema: z.object({
+                  file: Profile.openapi({
+                    encoding: {
+                      contentType: 'application/json',
+                    },
+                  }),
+                }),
+              },
+            },
+          },
+        },
+      });
+
+      const document = generateDocumentWithPossibleWebhooks(
+        registry.definitions
+      );
+      const response = document[rootDocPath]?.['/']?.get?.responses?.[
+        '200'
+      ] as any;
+
+      expect(response.content['application/json']).toEqual({
+        schema: {
+          type: 'object',
+          properties: {
+            file: {
+              $ref: '#/components/schemas/Profile',
+            },
+          },
+          required: ['file'],
         },
       });
     });
@@ -567,3 +622,158 @@ describe.each`
   ${'Routes'}   | ${'registerPath'}    | ${'paths'}
   ${'Webhooks'} | ${'registerWebhook'} | ${'webhooks'}
 `('$type', routeTests);
+
+describe('OpenAPI 3.0 request and response encoding', () => {
+  it('lifts multipart field encoding from schema metadata for request bodies', () => {
+    const Profile = z
+      .object({
+        name: z.string(),
+      })
+      .openapi('Profile');
+
+    const { requestBody } = generateDataForRoute({
+      request: {
+        body: {
+          required: true,
+          content: {
+            'multipart/form-data': {
+              schema: z.object({
+                file: Profile.openapi({
+                  description: 'JSON file containing the payload',
+                  encoding: {
+                    contentType: 'application/json',
+                  },
+                }),
+              }),
+              encoding: {
+                file: {
+                  explode: true,
+                },
+              },
+            },
+          },
+        },
+      },
+    });
+
+    expect(requestBody).toEqual({
+      required: true,
+      content: {
+        'multipart/form-data': {
+          schema: {
+            type: 'object',
+            properties: {
+              file: {
+                allOf: [
+                  { $ref: '#/components/schemas/Profile' },
+                  { description: 'JSON file containing the payload' },
+                ],
+              },
+            },
+            required: ['file'],
+          },
+          encoding: {
+            file: {
+              contentType: 'application/json',
+              explode: true,
+            },
+          },
+        },
+      },
+    });
+  });
+
+  it('does not emit generated encoding for non-form request bodies', () => {
+    const Profile = z
+      .object({
+        name: z.string(),
+      })
+      .openapi('Profile');
+
+    const { requestBody } = generateDataForRoute({
+      request: {
+        body: {
+          required: true,
+          content: {
+            'application/json': {
+              schema: z.object({
+                file: Profile.openapi({
+                  description: 'JSON payload',
+                  encoding: {
+                    contentType: 'application/json',
+                  },
+                }),
+              }),
+            },
+          },
+        },
+      },
+    });
+
+    expect(requestBody).toEqual({
+      required: true,
+      content: {
+        'application/json': {
+          schema: {
+            type: 'object',
+            properties: {
+              file: {
+                allOf: [
+                  { $ref: '#/components/schemas/Profile' },
+                  { description: 'JSON payload' },
+                ],
+              },
+            },
+            required: ['file'],
+          },
+        },
+      },
+    });
+  });
+
+  it('does not emit generated encoding for response content', () => {
+    const registry = new OpenAPIRegistry();
+
+    const Profile = z
+      .object({
+        name: z.string(),
+      })
+      .openapi('Profile');
+
+    registry.registerPath({
+      method: 'get',
+      path: '/',
+      responses: {
+        200: {
+          description: 'Simple response',
+          content: {
+            'application/json': {
+              schema: z.object({
+                file: Profile.openapi({
+                  encoding: {
+                    contentType: 'application/json',
+                  },
+                }),
+              }),
+            },
+          },
+        },
+      },
+    });
+
+    const document = generateDocumentV30(registry.definitions);
+    const response = document.paths['/']?.get?.responses?.['200'] as any;
+
+    expect(response.content['application/json']).toEqual({
+      schema: {
+        type: 'object',
+        properties: {
+          file: {
+            $ref: '#/components/schemas/Profile',
+          },
+        },
+        required: ['file'],
+      },
+    });
+  });
+});

--- a/spec/routes/index.spec.ts
+++ b/spec/routes/index.spec.ts
@@ -508,6 +508,57 @@ const routeTests = ({
         },
       });
     });
+
+    it('does not emit generated encoding for non-form request bodies', () => {
+      const registry = new OpenAPIRegistry();
+
+      const Profile = z
+        .object({
+          name: z.string(),
+        })
+        .openapi('Profile');
+
+      const route = createTestRoute({
+        request: {
+          body: {
+            required: true,
+            content: {
+              'application/json': {
+                schema: z.object({
+                  file: Profile.openapi({
+                    description: 'JSON payload',
+                    encoding: {
+                      contentType: 'application/json',
+                    },
+                  }),
+                }),
+              },
+            },
+          },
+        },
+      });
+
+      registry[registerFunction](route);
+
+      const document = generateDocumentWithPossibleWebhooks(
+        registry.definitions
+      );
+
+      const requestBody = document[rootDocPath]?.['/']?.get?.requestBody as any;
+
+      expect(requestBody.content['application/json']).toEqual({
+        schema: {
+          type: 'object',
+          properties: {
+            file: {
+              $ref: '#/components/schemas/Profile',
+              description: 'JSON payload',
+            },
+          },
+          required: ['file'],
+        },
+      });
+    });
   });
 };
 

--- a/spec/routes/index.spec.ts
+++ b/spec/routes/index.spec.ts
@@ -8,7 +8,6 @@ import {
   generateDataForRoute,
   testDocConfig,
 } from '../lib/helpers';
-import { OpenApiGeneratorV3 } from '../../src/v3.0/openapi-generator';
 import { OpenApiGeneratorV31 } from '../../src/v3.1/openapi-generator';
 
 // We need OpenAPIObject31 because of the webhooks property.
@@ -20,10 +19,6 @@ function generateDocumentWithPossibleWebhooks(
     ...testDocConfig,
     openapi: '3.1.0',
   });
-}
-
-function generateDocumentV30(definitions: (OpenAPIDefinitions | ZodType)[]) {
-  return new OpenApiGeneratorV3(definitions).generateDocument(testDocConfig);
 }
 
 const routeTests = ({
@@ -258,56 +253,6 @@ const routeTests = ({
         },
       });
     });
-
-    it('does not emit generated encoding for response content', () => {
-      const registry = new OpenAPIRegistry();
-
-      const Profile = z
-        .object({
-          name: z.string(),
-        })
-        .openapi('Profile');
-
-      registry[registerFunction]({
-        method: 'get',
-        path: '/',
-        responses: {
-          200: {
-            description: 'Simple response',
-            content: {
-              'application/json': {
-                schema: z.object({
-                  file: Profile.openapi({
-                    encoding: {
-                      contentType: 'application/json',
-                    },
-                  }),
-                }),
-              },
-            },
-          },
-        },
-      });
-
-      const document = generateDocumentWithPossibleWebhooks(
-        registry.definitions
-      );
-      const response = document[rootDocPath]?.['/']?.get?.responses?.[
-        '200'
-      ] as any;
-
-      expect(response.content['application/json']).toEqual({
-        schema: {
-          type: 'object',
-          properties: {
-            file: {
-              $ref: '#/components/schemas/Profile',
-            },
-          },
-          required: ['file'],
-        },
-      });
-    });
   });
 
   it('can generate paths with multiple examples', () => {
@@ -502,7 +447,7 @@ const routeTests = ({
       });
     });
 
-    it('lifts multipart field encoding from schema metadata and keeps field-local ref metadata', () => {
+    it('keeps explicit multipart encoding and field-local ref metadata', () => {
       const registry = new OpenAPIRegistry();
 
       const Profile = z
@@ -520,13 +465,11 @@ const routeTests = ({
                 schema: z.object({
                   file: Profile.openapi({
                     description: 'JSON file containing the payload',
-                    encoding: {
-                      contentType: 'application/json',
-                    },
                   }),
                 }),
                 encoding: {
                   file: {
+                    contentType: 'application/json',
                     explode: true,
                   },
                 },
@@ -563,57 +506,6 @@ const routeTests = ({
         },
       });
     });
-
-    it('does not emit generated encoding for non-form request bodies', () => {
-      const registry = new OpenAPIRegistry();
-
-      const Profile = z
-        .object({
-          name: z.string(),
-        })
-        .openapi('Profile');
-
-      const route = createTestRoute({
-        request: {
-          body: {
-            required: true,
-            content: {
-              'application/json': {
-                schema: z.object({
-                  file: Profile.openapi({
-                    description: 'JSON payload',
-                    encoding: {
-                      contentType: 'application/json',
-                    },
-                  }),
-                }),
-              },
-            },
-          },
-        },
-      });
-
-      registry[registerFunction](route);
-
-      const document = generateDocumentWithPossibleWebhooks(
-        registry.definitions
-      );
-
-      const requestBody = document[rootDocPath]?.['/']?.get?.requestBody as any;
-
-      expect(requestBody.content['application/json']).toEqual({
-        schema: {
-          type: 'object',
-          properties: {
-            file: {
-              $ref: '#/components/schemas/Profile',
-              description: 'JSON payload',
-            },
-          },
-          required: ['file'],
-        },
-      });
-    });
   });
 };
 
@@ -624,7 +516,7 @@ describe.each`
 `('$type', routeTests);
 
 describe('OpenAPI 3.0 request and response encoding', () => {
-  it('lifts multipart field encoding from schema metadata for request bodies', () => {
+  it('keeps explicit multipart encoding for request bodies', () => {
     const Profile = z
       .object({
         name: z.string(),
@@ -640,13 +532,11 @@ describe('OpenAPI 3.0 request and response encoding', () => {
               schema: z.object({
                 file: Profile.openapi({
                   description: 'JSON file containing the payload',
-                  encoding: {
-                    contentType: 'application/json',
-                  },
                 }),
               }),
               encoding: {
                 file: {
+                  contentType: 'application/json',
                   explode: true,
                 },
               },
@@ -679,100 +569,6 @@ describe('OpenAPI 3.0 request and response encoding', () => {
             },
           },
         },
-      },
-    });
-  });
-
-  it('does not emit generated encoding for non-form request bodies', () => {
-    const Profile = z
-      .object({
-        name: z.string(),
-      })
-      .openapi('Profile');
-
-    const { requestBody } = generateDataForRoute({
-      request: {
-        body: {
-          required: true,
-          content: {
-            'application/json': {
-              schema: z.object({
-                file: Profile.openapi({
-                  description: 'JSON payload',
-                  encoding: {
-                    contentType: 'application/json',
-                  },
-                }),
-              }),
-            },
-          },
-        },
-      },
-    });
-
-    expect(requestBody).toEqual({
-      required: true,
-      content: {
-        'application/json': {
-          schema: {
-            type: 'object',
-            properties: {
-              file: {
-                allOf: [
-                  { $ref: '#/components/schemas/Profile' },
-                  { description: 'JSON payload' },
-                ],
-              },
-            },
-            required: ['file'],
-          },
-        },
-      },
-    });
-  });
-
-  it('does not emit generated encoding for response content', () => {
-    const registry = new OpenAPIRegistry();
-
-    const Profile = z
-      .object({
-        name: z.string(),
-      })
-      .openapi('Profile');
-
-    registry.registerPath({
-      method: 'get',
-      path: '/',
-      responses: {
-        200: {
-          description: 'Simple response',
-          content: {
-            'application/json': {
-              schema: z.object({
-                file: Profile.openapi({
-                  encoding: {
-                    contentType: 'application/json',
-                  },
-                }),
-              }),
-            },
-          },
-        },
-      },
-    });
-
-    const document = generateDocumentV30(registry.definitions);
-    const response = document.paths['/']?.get?.responses?.['200'] as any;
-
-    expect(response.content['application/json']).toEqual({
-      schema: {
-        type: 'object',
-        properties: {
-          file: {
-            $ref: '#/components/schemas/Profile',
-          },
-        },
-        required: ['file'],
       },
     });
   });

--- a/spec/routes/index.spec.ts
+++ b/spec/routes/index.spec.ts
@@ -446,6 +446,68 @@ const routeTests = ({
         },
       });
     });
+
+    it('lifts multipart field encoding from schema metadata and keeps field-local ref metadata', () => {
+      const registry = new OpenAPIRegistry();
+
+      const Profile = z
+        .object({
+          name: z.string(),
+        })
+        .openapi('Profile');
+
+      const route = createTestRoute({
+        request: {
+          body: {
+            required: true,
+            content: {
+              'multipart/form-data': {
+                schema: z.object({
+                  file: Profile.openapi({
+                    description: 'JSON file containing the payload',
+                    encoding: {
+                      contentType: 'application/json',
+                    },
+                  }),
+                }),
+                encoding: {
+                  file: {
+                    explode: true,
+                  },
+                },
+              },
+            },
+          },
+        },
+      });
+
+      registry[registerFunction](route);
+
+      const document = generateDocumentWithPossibleWebhooks(
+        registry.definitions
+      );
+
+      const requestBody = document[rootDocPath]?.['/']?.get?.requestBody as any;
+
+      expect(requestBody.content['multipart/form-data']).toEqual({
+        schema: {
+          type: 'object',
+          properties: {
+            file: {
+              $ref: '#/components/schemas/Profile',
+              description: 'JSON file containing the payload',
+            },
+          },
+          required: ['file'],
+        },
+        encoding: {
+          file: {
+            contentType: 'application/json',
+            explode: true,
+          },
+        },
+      });
+    });
   });
 };
 

--- a/spec/type-definitions/zod-extensions.test-d.ts
+++ b/spec/type-definitions/zod-extensions.test-d.ts
@@ -13,7 +13,6 @@ import { expectType, expectAssignable } from 'tsd';
 import { z } from 'zod';
 import {
   extendZodWithOpenApi,
-  type ZodMultipartContentEncoding,
   type ZodOpenAPIMetadata,
   type RouteConfig,
   type ZodMediaTypeObject,
@@ -158,19 +157,13 @@ expectType<z.ZodOptional<z.ZodString>>(multipleOpenApi);
 const mediaTypeObject: ZodMediaTypeObject = {
   schema: userWithOpenApi, // Should compile without error
   example: { id: '1', name: 'Test', email: 'test@example.com' },
+  encoding: {
+    file: {
+      contentType: 'application/json',
+    },
+  },
 };
 expectAssignable<ZodMediaTypeObject>(mediaTypeObject);
-
-const multipartEncoding: ZodMultipartContentEncoding = {
-  contentType: 'application/json',
-};
-expectAssignable<ZodMultipartContentEncoding>(multipartEncoding);
-
-const multipartFieldMetadata: ZodOpenAPIMetadata = {
-  description: 'JSON multipart field',
-  encoding: multipartEncoding,
-};
-expectAssignable<ZodOpenAPIMetadata>(multipartFieldMetadata);
 
 /**
  * Test: ZodRequestBody should work with our schemas

--- a/spec/type-definitions/zod-extensions.test-d.ts
+++ b/spec/type-definitions/zod-extensions.test-d.ts
@@ -13,6 +13,7 @@ import { expectType, expectAssignable } from 'tsd';
 import { z } from 'zod';
 import {
   extendZodWithOpenApi,
+  type ZodMultipartContentEncoding,
   type ZodOpenAPIMetadata,
   type RouteConfig,
   type ZodMediaTypeObject,
@@ -159,6 +160,17 @@ const mediaTypeObject: ZodMediaTypeObject = {
   example: { id: '1', name: 'Test', email: 'test@example.com' },
 };
 expectAssignable<ZodMediaTypeObject>(mediaTypeObject);
+
+const multipartEncoding: ZodMultipartContentEncoding = {
+  contentType: 'application/json',
+};
+expectAssignable<ZodMultipartContentEncoding>(multipartEncoding);
+
+const multipartFieldMetadata: ZodOpenAPIMetadata = {
+  description: 'JSON multipart field',
+  encoding: multipartEncoding,
+};
+expectAssignable<ZodOpenAPIMetadata>(multipartFieldMetadata);
 
 /**
  * Test: ZodRequestBody should work with our schemas

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,4 @@
-export {
-  ZodMultipartContentEncoding,
-  ZodOpenAPIMetadata,
-  extendZodWithOpenApi,
-} from './zod-extensions';
+export { ZodOpenAPIMetadata, extendZodWithOpenApi } from './zod-extensions';
 export * from './openapi-metadata';
 export {
   OpenAPIRegistry,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,8 @@
-export { ZodOpenAPIMetadata, extendZodWithOpenApi } from './zod-extensions';
+export {
+  ZodMultipartContentEncoding,
+  ZodOpenAPIMetadata,
+  extendZodWithOpenApi,
+} from './zod-extensions';
 export * from './openapi-metadata';
 export {
   OpenAPIRegistry,

--- a/src/metadata.ts
+++ b/src/metadata.ts
@@ -113,10 +113,7 @@ export class Metadata {
    * metadata properties
    */
   static buildSchemaMetadata(metadata: Partial<ZodOpenAPIMetadata>) {
-    return omitBy(
-      omit(metadata, ['encoding', 'param', '_internal']),
-      isUndefined
-    );
+    return omitBy(omit(metadata, ['param', '_internal']), isUndefined);
   }
 
   static buildParameterMetadata(

--- a/src/metadata.ts
+++ b/src/metadata.ts
@@ -23,18 +23,9 @@ export class Metadata {
   ): ZodOpenApiFullMetadata | undefined {
     const currentMetadata = this.getMetadataFromRegistry(schema);
 
-    const {
-      baseMetadata: currentBaseMetadata,
-      ...currentInternalMetadata
-    } = currentMetadata?._internal ?? {};
-    const {
-      baseMetadata: providedBaseMetadata,
-      ...providedInternalMetadata
-    } = metadata?._internal ?? {};
-
     const _internal = {
-      ...currentInternalMetadata,
-      ...providedInternalMetadata,
+      ...currentMetadata?._internal,
+      ...metadata?._internal,
     };
 
     const param = {
@@ -155,9 +146,7 @@ export class Metadata {
     zodSchema: ZodType<T>
   ): ZodOpenApiFullMetadata<T> | undefined {
     return this.getMetadataFromInternalRegistry(zodSchema)?._internal
-      ?.baseMetadata as
-      | ZodOpenApiFullMetadata<T>
-      | undefined;
+      ?.baseMetadata as ZodOpenApiFullMetadata<T> | undefined;
   }
 
   static cloneSchemaWithMetadata<T extends ZodType>(
@@ -246,14 +235,13 @@ export class Metadata {
     }
 
     const { _internal, ...rest } = internal;
-    const { baseMetadata, ...internalMetadata } = _internal ?? {};
 
     const { id, title, ...restGeneral } = general ?? {};
 
     return {
       _internal: {
         ...(id ? { refId: id } : {}),
-        ...internalMetadata,
+        ..._internal,
       },
       ...rest,
       ...(title ? { description: title } : {}),

--- a/src/metadata.ts
+++ b/src/metadata.ts
@@ -23,9 +23,18 @@ export class Metadata {
   ): ZodOpenApiFullMetadata | undefined {
     const currentMetadata = this.getMetadataFromRegistry(schema);
 
+    const {
+      baseMetadata: currentBaseMetadata,
+      ...currentInternalMetadata
+    } = currentMetadata?._internal ?? {};
+    const {
+      baseMetadata: providedBaseMetadata,
+      ...providedInternalMetadata
+    } = metadata?._internal ?? {};
+
     const _internal = {
-      ...currentMetadata?._internal,
-      ...metadata?._internal,
+      ...currentInternalMetadata,
+      ...providedInternalMetadata,
     };
 
     const param = {
@@ -113,7 +122,10 @@ export class Metadata {
    * metadata properties
    */
   static buildSchemaMetadata(metadata: Partial<ZodOpenAPIMetadata>) {
-    return omitBy(omit(metadata, ['param', '_internal']), isUndefined);
+    return omitBy(
+      omit(metadata, ['encoding', 'param', '_internal']),
+      isUndefined
+    );
   }
 
   static buildParameterMetadata(
@@ -137,6 +149,27 @@ export class Metadata {
 
   static getRefId<T extends any>(zodSchema: ZodType<T>) {
     return this.getInternalMetadata(zodSchema)?.refId;
+  }
+
+  static getBaseMetadata<T extends any>(
+    zodSchema: ZodType<T>
+  ): ZodOpenApiFullMetadata<T> | undefined {
+    return this.getMetadataFromInternalRegistry(zodSchema)?._internal
+      ?.baseMetadata as
+      | ZodOpenApiFullMetadata<T>
+      | undefined;
+  }
+
+  static cloneSchemaWithMetadata<T extends ZodType>(
+    zodSchema: T,
+    metadata: ZodOpenApiFullMetadata
+  ): T {
+    const SchemaConstructor = zodSchema.constructor as new (def: any) => T;
+    const clone = new SchemaConstructor(zodSchema._def);
+
+    this.setMetadataInRegistry(clone, metadata);
+
+    return clone;
   }
 
   static unwrapChained(schema: ZodType): ZodType {
@@ -213,13 +246,14 @@ export class Metadata {
     }
 
     const { _internal, ...rest } = internal;
+    const { baseMetadata, ...internalMetadata } = _internal ?? {};
 
     const { id, title, ...restGeneral } = general ?? {};
 
     return {
       _internal: {
         ...(id ? { refId: id } : {}),
-        ..._internal,
+        ...internalMetadata,
       },
       ...rest,
       ...(title ? { description: title } : {}),

--- a/src/metadata.ts
+++ b/src/metadata.ts
@@ -232,13 +232,14 @@ export class Metadata {
     }
 
     const { _internal, ...rest } = internal;
+    const { baseMetadata, ...internalMetadata } = _internal ?? {};
 
     const { id, title, ...restGeneral } = general ?? {};
 
     return {
       _internal: {
         ...(id ? { refId: id } : {}),
-        ..._internal,
+        ...internalMetadata,
       },
       ...rest,
       ...(title ? { description: title } : {}),

--- a/src/openapi-generator.ts
+++ b/src/openapi-generator.ts
@@ -25,6 +25,7 @@ import {
   RouteConfig,
   RouteParameter,
   ZodContentObject,
+  ZodMediaTypeObject,
   ZodRequestBody,
 } from './openapi-registry';
 import {
@@ -74,6 +75,11 @@ export interface OpenApiVersionSpecifics {
     | ReferenceObject
     | { allOf: (ReferenceObject | { nullable: boolean })[] }
     | { oneOf: (ReferenceObject | { type: 'null' })[] };
+
+  composeReferenceWithMetadata(
+    ref: ReferenceObject,
+    metadata: SchemaObject | ReferenceObject
+  ): SchemaObject | ReferenceObject;
 
   mapTupleItems(schemas: (SchemaObject | ReferenceObject)[]): {
     items?: SchemaObject | ReferenceObject;
@@ -205,7 +211,7 @@ export class OpenAPIGenerator {
 
   private generateSingle(definition: OpenAPIDefinitions | ZodType): void {
     if (!('type' in definition)) {
-      this.generateSchemaWithRef(definition);
+      this.generateSchemaWithRef(definition, false);
       return;
     }
 
@@ -215,7 +221,7 @@ export class OpenAPIGenerator {
         return;
 
       case 'schema':
-        this.generateSchemaWithRef(definition.schema);
+        this.generateSchemaWithRef(definition.schema, false);
         return;
 
       case 'route':
@@ -549,9 +555,10 @@ export class OpenAPIGenerator {
     // Do not calculate schema metadata overrides if type is provided in .openapi
     // https://github.com/asteasolutions/zod-to-openapi/pull/52/files/8ff707fe06e222bc573ed46cf654af8ee0b0786d#r996430801
     if (newMetadata.type) {
-      return {
-        allOf: [referenceObject, newMetadata],
-      };
+      return this.versionSpecifics.composeReferenceWithMetadata(
+        referenceObject,
+        newMetadata
+      );
     }
 
     // New metadata from zodSchema properties.
@@ -566,9 +573,10 @@ export class OpenAPIGenerator {
     );
 
     if (Object.keys(appliedMetadata).length > 0) {
-      return {
-        allOf: [referenceObject, appliedMetadata],
-      };
+      return this.versionSpecifics.composeReferenceWithMetadata(
+        referenceObject,
+        appliedMetadata
+      );
     }
 
     return referenceObject;
@@ -581,13 +589,18 @@ export class OpenAPIGenerator {
    *
    * Should be used for nested objects, arrays, etc.
    */
-  private generateSchemaWithRef(zodSchema: ZodType) {
+  private generateSchemaWithRef(zodSchema: ZodType, useBaseMetadata = true) {
     const refId = Metadata.getRefId(zodSchema);
 
     if (refId && !this.schemaRefs[refId]) {
-      this.schemaRefs[refId] = this.generateSimpleSchema(zodSchema);
+      const baseMetadata = useBaseMetadata
+        ? Metadata.getBaseMetadata(zodSchema)
+        : undefined;
+      const schemaToRegister = baseMetadata
+        ? Metadata.cloneSchemaWithMetadata(zodSchema, baseMetadata)
+        : zodSchema;
 
-      return { $ref: this.generateSchemaRef(refId) };
+      this.schemaRefs[refId] = this.generateSimpleSchema(schemaToRegister);
     }
 
     return this.generateSimpleSchema(zodSchema);
@@ -782,17 +795,74 @@ export class OpenAPIGenerator {
   }
 
   private getBodyContent(content: ZodContentObject): ContentObject {
-    return mapValues(content, config => {
-      if (!config || !isAnyZodType(config.schema)) {
-        return config;
+    return mapValues(content, config => this.getMediaTypeObject(config));
+  }
+
+  private getMediaTypeObject(
+    config: ZodMediaTypeObject | undefined
+  ): ContentObject[string] {
+    if (!config || !isAnyZodType(config.schema)) {
+      return config as ContentObject[string];
+    }
+
+    const { schema: configSchema, encoding, ...rest } = config;
+
+    const schema = this.generateSchemaWithRef(configSchema);
+    const generatedEncoding = this.getSchemaEncoding(configSchema);
+    const mergedEncoding = this.mergeEncodingObjects(generatedEncoding, encoding);
+
+    return {
+      schema,
+      ...rest,
+      ...(mergedEncoding ? { encoding: mergedEncoding } : {}),
+    };
+  }
+
+  private getSchemaEncoding(zodSchema: ZodType): ZodMediaTypeObject['encoding'] {
+    const unwrappedSchema = Metadata.unwrapChained(zodSchema);
+
+    if (!isZodType(unwrappedSchema, 'ZodObject')) {
+      return undefined;
+    }
+
+    const encoding = Object.entries(unwrappedSchema.def.shape).reduce<
+      NonNullable<ZodMediaTypeObject['encoding']>
+    >((result, [key, schema]) => {
+      const propertyEncoding = Metadata.getOpenApiMetadata(schema)?.encoding;
+
+      if (propertyEncoding) {
+        result[key] = propertyEncoding;
       }
 
-      const { schema: configSchema, ...rest } = config;
+      return result;
+    }, {});
 
-      const schema = this.generateSchemaWithRef(configSchema);
+    return Object.keys(encoding).length > 0 ? encoding : undefined;
+  }
 
-      return { schema, ...rest };
-    });
+  private mergeEncodingObjects(
+    generatedEncoding: ZodMediaTypeObject['encoding'],
+    explicitEncoding: ZodMediaTypeObject['encoding']
+  ): ZodMediaTypeObject['encoding'] {
+    if (!generatedEncoding) {
+      return explicitEncoding;
+    }
+
+    if (!explicitEncoding) {
+      return generatedEncoding;
+    }
+
+    const mergedEncoding = Object.fromEntries(
+      Object.keys({ ...generatedEncoding, ...explicitEncoding }).map(key => [
+        key,
+        {
+          ...(generatedEncoding[key] ?? {}),
+          ...(explicitEncoding[key] ?? {}),
+        },
+      ])
+    );
+
+    return Object.keys(mergedEncoding).length > 0 ? mergedEncoding : undefined;
   }
 
   private toOpenAPISchema<T>(

--- a/src/openapi-generator.ts
+++ b/src/openapi-generator.ts
@@ -619,7 +619,9 @@ export class OpenAPIGenerator {
 
     const { content, ...rest } = requestBody;
 
-    const requestBodyContent = this.getBodyContent(content);
+    const requestBodyContent = this.getBodyContent(content, {
+      kind: 'request',
+    });
 
     return {
       ...rest,
@@ -755,7 +757,7 @@ export class OpenAPIGenerator {
     const { content, headers, ...rest } = response;
 
     const responseContent = content
-      ? { content: this.getBodyContent(content) }
+      ? { content: this.getBodyContent(content, { kind: 'response' }) }
       : {};
 
     if (!headers) {
@@ -794,12 +796,24 @@ export class OpenAPIGenerator {
     return responseHeaders;
   }
 
-  private getBodyContent(content: ZodContentObject): ContentObject {
-    return mapValues(content, config => this.getMediaTypeObject(config));
+  private getBodyContent(
+    content: ZodContentObject,
+    context: { kind: 'request' | 'response' }
+  ): ContentObject {
+    return Object.fromEntries(
+      Object.entries(content).map(([mediaType, config]) => [
+        mediaType,
+        this.getMediaTypeObject(config, {
+          ...context,
+          mediaType,
+        }),
+      ])
+    );
   }
 
   private getMediaTypeObject(
-    config: ZodMediaTypeObject | undefined
+    config: ZodMediaTypeObject | undefined,
+    context: { kind: 'request' | 'response'; mediaType: string }
   ): ContentObject[string] {
     if (!config || !isAnyZodType(config.schema)) {
       return config as ContentObject[string];
@@ -808,8 +822,13 @@ export class OpenAPIGenerator {
     const { schema: configSchema, encoding, ...rest } = config;
 
     const schema = this.generateSchemaWithRef(configSchema);
-    const generatedEncoding = this.getSchemaEncoding(configSchema);
-    const mergedEncoding = this.mergeEncodingObjects(generatedEncoding, encoding);
+    const generatedEncoding = this.shouldGenerateEncoding(context)
+      ? this.getSchemaEncoding(configSchema)
+      : undefined;
+    const mergedEncoding = this.mergeEncodingObjects(
+      generatedEncoding,
+      encoding
+    );
 
     return {
       schema,
@@ -818,7 +837,9 @@ export class OpenAPIGenerator {
     };
   }
 
-  private getSchemaEncoding(zodSchema: ZodType): ZodMediaTypeObject['encoding'] {
+  private getSchemaEncoding(
+    zodSchema: ZodType
+  ): ZodMediaTypeObject['encoding'] {
     const unwrappedSchema = Metadata.unwrapChained(zodSchema);
 
     if (!isZodType(unwrappedSchema, 'ZodObject')) {
@@ -863,6 +884,17 @@ export class OpenAPIGenerator {
     );
 
     return Object.keys(mergedEncoding).length > 0 ? mergedEncoding : undefined;
+  }
+
+  private shouldGenerateEncoding(context: {
+    kind: 'request' | 'response';
+    mediaType: string;
+  }) {
+    return (
+      context.kind === 'request' &&
+      (context.mediaType.startsWith('multipart/') ||
+        context.mediaType === 'application/x-www-form-urlencoded')
+    );
   }
 
   private toOpenAPISchema<T>(

--- a/src/openapi-generator.ts
+++ b/src/openapi-generator.ts
@@ -619,9 +619,7 @@ export class OpenAPIGenerator {
 
     const { content, ...rest } = requestBody;
 
-    const requestBodyContent = this.getBodyContent(content, {
-      kind: 'request',
-    });
+    const requestBodyContent = this.getBodyContent(content);
 
     return {
       ...rest,
@@ -757,7 +755,7 @@ export class OpenAPIGenerator {
     const { content, headers, ...rest } = response;
 
     const responseContent = content
-      ? { content: this.getBodyContent(content, { kind: 'response' }) }
+      ? { content: this.getBodyContent(content) }
       : {};
 
     if (!headers) {
@@ -796,105 +794,25 @@ export class OpenAPIGenerator {
     return responseHeaders;
   }
 
-  private getBodyContent(
-    content: ZodContentObject,
-    context: { kind: 'request' | 'response' }
-  ): ContentObject {
-    return Object.fromEntries(
-      Object.entries(content).map(([mediaType, config]) => [
-        mediaType,
-        this.getMediaTypeObject(config, {
-          ...context,
-          mediaType,
-        }),
-      ])
-    );
+  private getBodyContent(content: ZodContentObject): ContentObject {
+    return mapValues(content, config => this.getMediaTypeObject(config));
   }
 
   private getMediaTypeObject(
-    config: ZodMediaTypeObject | undefined,
-    context: { kind: 'request' | 'response'; mediaType: string }
+    config: ZodMediaTypeObject | undefined
   ): ContentObject[string] {
     if (!config || !isAnyZodType(config.schema)) {
       return config as ContentObject[string];
     }
 
-    const { schema: configSchema, encoding, ...rest } = config;
+    const { schema: configSchema, ...rest } = config;
 
     const schema = this.generateSchemaWithRef(configSchema);
-    const generatedEncoding = this.shouldGenerateEncoding(context)
-      ? this.getSchemaEncoding(configSchema)
-      : undefined;
-    const mergedEncoding = this.mergeEncodingObjects(
-      generatedEncoding,
-      encoding
-    );
 
     return {
       schema,
       ...rest,
-      ...(mergedEncoding ? { encoding: mergedEncoding } : {}),
     };
-  }
-
-  private getSchemaEncoding(
-    zodSchema: ZodType
-  ): ZodMediaTypeObject['encoding'] {
-    const unwrappedSchema = Metadata.unwrapChained(zodSchema);
-
-    if (!isZodType(unwrappedSchema, 'ZodObject')) {
-      return undefined;
-    }
-
-    const encoding = Object.entries(unwrappedSchema.def.shape).reduce<
-      NonNullable<ZodMediaTypeObject['encoding']>
-    >((result, [key, schema]) => {
-      const propertyEncoding = Metadata.getOpenApiMetadata(schema)?.encoding;
-
-      if (propertyEncoding) {
-        result[key] = propertyEncoding;
-      }
-
-      return result;
-    }, {});
-
-    return Object.keys(encoding).length > 0 ? encoding : undefined;
-  }
-
-  private mergeEncodingObjects(
-    generatedEncoding: ZodMediaTypeObject['encoding'],
-    explicitEncoding: ZodMediaTypeObject['encoding']
-  ): ZodMediaTypeObject['encoding'] {
-    if (!generatedEncoding) {
-      return explicitEncoding;
-    }
-
-    if (!explicitEncoding) {
-      return generatedEncoding;
-    }
-
-    const mergedEncoding = Object.fromEntries(
-      Object.keys({ ...generatedEncoding, ...explicitEncoding }).map(key => [
-        key,
-        {
-          ...(generatedEncoding[key] ?? {}),
-          ...(explicitEncoding[key] ?? {}),
-        },
-      ])
-    );
-
-    return Object.keys(mergedEncoding).length > 0 ? mergedEncoding : undefined;
-  }
-
-  private shouldGenerateEncoding(context: {
-    kind: 'request' | 'response';
-    mediaType: string;
-  }) {
-    return (
-      context.kind === 'request' &&
-      (context.mediaType.startsWith('multipart/') ||
-        context.mediaType === 'application/x-www-form-urlencoded')
-    );
   }
 
   private toOpenAPISchema<T>(

--- a/src/v3.0/specifics.ts
+++ b/src/v3.0/specifics.ts
@@ -1,7 +1,11 @@
 import type { ReferenceObject, SchemaObject } from 'openapi3-ts/oas30';
 import type { $ZodCheckGreaterThan, $ZodCheckLessThan } from 'zod/core';
 import { OpenApiVersionSpecifics } from '../openapi-generator';
-import { ZodNumericCheck, SchemaObject as CommonSchemaObject } from '../types';
+import {
+  ReferenceObject as CommonReferenceObject,
+  SchemaObject as CommonSchemaObject,
+  ZodNumericCheck,
+} from '../types';
 import { objectEquals, uniq } from '../lib/lodash';
 
 export class OpenApiGeneratorV30Specifics implements OpenApiVersionSpecifics {
@@ -42,6 +46,15 @@ export class OpenApiGeneratorV30Specifics implements OpenApiVersionSpecifics {
       };
     }
     return ref;
+  }
+
+  composeReferenceWithMetadata(
+    ref: CommonReferenceObject,
+    metadata: CommonSchemaObject | CommonReferenceObject
+  ): CommonSchemaObject | CommonReferenceObject {
+    return {
+      allOf: [ref, metadata],
+    };
   }
 
   mapTupleItems(schemas: (CommonSchemaObject | ReferenceObject)[]) {

--- a/src/v3.1/specifics.ts
+++ b/src/v3.1/specifics.ts
@@ -5,7 +5,11 @@ import type {
 } from 'openapi3-ts/oas31';
 import type { $ZodCheckGreaterThan, $ZodCheckLessThan } from 'zod/core';
 import { OpenApiVersionSpecifics } from '../openapi-generator';
-import { ZodNumericCheck, SchemaObject as CommonSchemaObject } from '../types';
+import {
+  ReferenceObject as CommonReferenceObject,
+  SchemaObject as CommonSchemaObject,
+  ZodNumericCheck,
+} from '../types';
 import { objectEquals, uniq } from '../lib/lodash';
 
 export class OpenApiGeneratorV31Specifics implements OpenApiVersionSpecifics {
@@ -59,6 +63,16 @@ export class OpenApiGeneratorV31Specifics implements OpenApiVersionSpecifics {
       };
     }
     return ref;
+  }
+
+  composeReferenceWithMetadata(
+    ref: CommonReferenceObject,
+    metadata: CommonSchemaObject | CommonReferenceObject
+  ): CommonSchemaObject | CommonReferenceObject {
+    return {
+      ...ref,
+      ...metadata,
+    } as CommonSchemaObject & CommonReferenceObject;
   }
 
   mapTupleItems(schemas: (CommonSchemaObject | ReferenceObject)[]) {

--- a/src/zod-extensions.ts
+++ b/src/zod-extensions.ts
@@ -1,10 +1,8 @@
 import {
-  EncodingPropertyObject as EncodingPropertyObject30,
   ParameterObject as ParameterObject30,
   SchemaObject as SchemaObject30,
 } from 'openapi3-ts/oas30';
 import {
-  EncodingPropertyObject as EncodingPropertyObject31,
   ParameterObject as ParameterObject31,
   SchemaObject as SchemaObject31,
 } from 'openapi3-ts/oas31';
@@ -19,17 +17,12 @@ type ExampleValue<T> = T extends Date ? string : T;
 type ParameterObject = ParameterObject30 | ParameterObject31;
 type SchemaObject = SchemaObject30 | SchemaObject31;
 
-export type ZodMultipartContentEncoding =
-  | EncodingPropertyObject30
-  | EncodingPropertyObject31;
-
 export type UnionPreferredType = 'oneOf' | 'anyOf';
 
 export type ZodOpenAPIMetadata<T = any, E = ExampleValue<T>> = Omit<
   SchemaObject,
   'example' | 'examples' | 'default'
 > & {
-  encoding?: ZodMultipartContentEncoding;
   param?: Partial<ParameterObject> & { example?: E };
   example?: E;
   examples?: E[];

--- a/src/zod-extensions.ts
+++ b/src/zod-extensions.ts
@@ -1,8 +1,10 @@
 import {
+  EncodingPropertyObject as EncodingPropertyObject30,
   ParameterObject as ParameterObject30,
   SchemaObject as SchemaObject30,
 } from 'openapi3-ts/oas30';
 import {
+  EncodingPropertyObject as EncodingPropertyObject31,
   ParameterObject as ParameterObject31,
   SchemaObject as SchemaObject31,
 } from 'openapi3-ts/oas31';
@@ -17,12 +19,17 @@ type ExampleValue<T> = T extends Date ? string : T;
 type ParameterObject = ParameterObject30 | ParameterObject31;
 type SchemaObject = SchemaObject30 | SchemaObject31;
 
+export type ZodMultipartContentEncoding =
+  | EncodingPropertyObject30
+  | EncodingPropertyObject31;
+
 export type UnionPreferredType = 'oneOf' | 'anyOf';
 
 export type ZodOpenAPIMetadata<T = any, E = ExampleValue<T>> = Omit<
   SchemaObject,
   'example' | 'examples' | 'default'
 > & {
+  encoding?: ZodMultipartContentEncoding;
   param?: Partial<ParameterObject> & { example?: E };
   example?: E;
   examples?: E[];
@@ -43,6 +50,7 @@ export interface OpenApiOptions {
  * method has an explicit return type of ZodOpenAPIInternalMetadata.
  */
 interface InternalUserOnlyZodOpenAPIInternalMetadata extends OpenApiOptions {
+  baseMetadata?: ZodOpenApiFullMetadataForRegistry<any>;
   refId?: string;
   extendedFrom?: { refId: string; schema: any };
 }
@@ -135,9 +143,28 @@ export function extendZodWithOpenApi(zod: typeof z) {
     const { _internal: internalMetadata, ...currentMetadata } =
       allMetadata ?? {};
 
+    const baseMetadata =
+      internalMetadata?.baseMetadata ??
+      (internalMetadata?.refId && !refId
+        ? {
+            ...(Object.keys(currentMetadata).length > 0
+              ? currentMetadata
+              : undefined),
+            ...(internalMetadata
+              ? {
+                  _internal: {
+                    ...internalMetadata,
+                    baseMetadata: undefined,
+                  },
+                }
+              : undefined),
+          }
+        : undefined);
+
     const _internal = {
       ...internalMetadata,
       ...options,
+      ...(baseMetadata ? { baseMetadata } : undefined),
       ...(refId ? { refId } : undefined),
     };
 

--- a/src/zod-extensions.ts
+++ b/src/zod-extensions.ts
@@ -139,23 +139,11 @@ export function extendZodWithOpenApi(zod: typeof z) {
     const { _internal: _ignoredInternalMetadata, ...currentMetadata } =
       allMetadata ?? {};
 
-    const baseMetadata =
-      internalMetadata?.baseMetadata ??
-      (internalMetadata?.refId && !refId
-        ? {
-            ...(Object.keys(currentMetadata).length > 0
-              ? currentMetadata
-              : undefined),
-            ...(internalMetadata
-              ? {
-                  _internal: {
-                    ...internalMetadata,
-                    baseMetadata: undefined,
-                  },
-                }
-              : undefined),
-          }
-        : undefined);
+    const baseMetadata = getBaseMetadataForOverride(
+      currentMetadata,
+      internalMetadata,
+      refId
+    );
 
     const _internal = {
       ...internalMetadata,
@@ -259,6 +247,30 @@ export function extendZodWithOpenApi(zod: typeof z) {
     };
 
     return result;
+  };
+}
+
+function getBaseMetadataForOverride(
+  currentMetadata: Omit<ZodOpenApiFullMetadata, '_internal'>,
+  internalMetadata: ZodOpenApiFullMetadata['_internal'],
+  refId: string | undefined
+) {
+  if (internalMetadata?.baseMetadata) {
+    return internalMetadata.baseMetadata;
+  }
+
+  if (!internalMetadata?.refId || refId) {
+    return undefined;
+  }
+
+  const baseInternalMetadata = {
+    ...internalMetadata,
+    baseMetadata: undefined,
+  };
+
+  return {
+    ...(Object.keys(currentMetadata).length > 0 ? currentMetadata : undefined),
+    _internal: baseInternalMetadata,
   };
 }
 

--- a/src/zod-extensions.ts
+++ b/src/zod-extensions.ts
@@ -107,7 +107,7 @@ function preserveMetadataFromModifier<T extends ZodType, K extends keyof T>(
   zodSchema[modifier] = function (this: T, ...args: any[]) {
     const result = zodModifier.apply(this, args);
 
-    const meta = Metadata.getMetadataFromRegistry(this);
+    const meta = Metadata.getMetadataFromInternalRegistry(this);
 
     if (meta) {
       Metadata.setMetadataInRegistry(result, meta);
@@ -133,7 +133,10 @@ export function extendZodWithOpenApi(zod: typeof z) {
     const { param, ...restOfOpenApi } = metadata ?? {};
 
     const allMetadata = Metadata.getMetadataFromRegistry(this);
-    const { _internal: internalMetadata, ...currentMetadata } =
+    const internalRegistryMetadata =
+      Metadata.getMetadataFromInternalRegistry(this);
+    const { _internal: internalMetadata } = internalRegistryMetadata ?? {};
+    const { _internal: _ignoredInternalMetadata, ...currentMetadata } =
       allMetadata ?? {};
 
     const baseMetadata =


### PR DESCRIPTION
## Summary

This PR fixes referenced-schema metadata handling so OpenAPI 3.1 can emit valid sibling schema metadata next to `$ref`, while preserving valid OpenAPI 3.0 output.

## What changed

- add version-specific reference composition:
  - OpenAPI 3.1 emits sibling schema metadata next to `$ref`
  - OpenAPI 3.0 keeps wrapping metadata with `allOf`
- preserve base component metadata when field-level overrides are applied to referenced schemas and then wrapped with modifiers like `nullable()`
- keep `baseMetadata` internal to registry plumbing
- add regression coverage for:
  - OpenAPI 3.1 sibling metadata on referenced schemas
  - wrapped ref overrides not mutating shared component schemas
  - OpenAPI 3.0 compatibility for the same override paths
  - explicit multipart request-body encoding staying valid in both 3.0 and 3.1

## Notes

- full test suite, type tests, and build pass

Closes #376.

## Validation

`npm test`

`npm run build`
