### PR TITLE
fix: force required=true for path params (handles z.coerce in Zod 4)

### DIFF
--- a/spec/routes/parameters.spec.ts
+++ b/spec/routes/parameters.spec.ts
@@ -226,6 +226,24 @@ describe('parameters', () => {
         },
       ]);
     });
+
+    it('generates required: true for path parameters with z.coerce.number() (Zod 4 compatibility)', () => {
+      const { parameters } = generateDataForRoute({
+        request: { params: z.object({ id: z.coerce.number() }) },
+      });
+
+      expect(parameters).toEqual([
+        {
+          in: 'path',
+          name: 'id',
+          required: true,
+          schema: {
+            type: 'number',
+            nullable: true,
+          },
+        },
+      ]);
+    });
   });
 
   describe('cookies', () => {

--- a/src/openapi-generator.ts
+++ b/src/openapi-generator.ts
@@ -423,6 +423,10 @@ export class OpenAPIGenerator {
       externalParamMetadata
     );
 
+    if (paramLocation === 'path') {
+      baseParameter.required = true;
+    }
+
     return {
       ...baseParameter,
       in: paramLocation,


### PR DESCRIPTION
Closes #360 — path params incorrectly getting `required: false` when using `z.coerce.*()` in Zod 4.

Root cause: Zod 4's `z.coerce.number().safeParse(null).success = true`, making `isNullableSchema()` return `true`, which combined with the nullable check in openapi-generator produces `required = false`.

Fix: After `generateSimpleParameter()` for path params, force `parameter.required = true`.