### PR TITLE
fix: emit nullable refs as anyOf in OpenAPI 3.1

### DIFF
--- a/spec/modifiers/nullable.spec.ts
+++ b/spec/modifiers/nullable.spec.ts
@@ -83,13 +83,62 @@ describe('nullable', () => {
           type: 'object',
           properties: {
             key: {
-              allOf: [
+              anyOf: [
                 { $ref: '#/components/schemas/String' },
-                { type: ['string', 'null'] },
+                { type: 'null' },
               ],
             },
           },
           required: ['key'],
+        },
+      },
+      { version: '3.1.0' }
+    );
+  });
+
+  it('supports nullable registered object schemas as refs in open api 3.1.0', () => {
+    const ObjectSchema = z
+      .object({
+        id: z.string().uuid(),
+        name: z.enum(['A', 'B', 'C']),
+      })
+      .openapi('Object');
+
+    const DetailSchema = z
+      .object({
+        nullableObject: ObjectSchema.nullable(),
+        unionObject: z.union([ObjectSchema, z.null()]),
+      })
+      .openapi('Detail');
+
+    expectSchema(
+      [ObjectSchema, DetailSchema],
+      {
+        Object: {
+          type: 'object',
+          properties: {
+            id: { type: 'string', format: 'uuid' },
+            name: { type: 'string', enum: ['A', 'B', 'C'] },
+          },
+          required: ['id', 'name'],
+        },
+        Detail: {
+          type: 'object',
+          properties: {
+            nullableObject: {
+              anyOf: [
+                { $ref: '#/components/schemas/Object' },
+                { type: 'null' },
+              ],
+            },
+            unionObject: {
+              anyOf: [
+                { $ref: '#/components/schemas/Object' },
+                { type: 'null' },
+              ],
+            },
+          },
+          required: ['nullableObject', 'unionObject'],
         },
       },
       { version: '3.1.0' }
@@ -184,15 +233,15 @@ describe('nullable', () => {
           required: ['key'],
           properties: {
             key: {
-              allOf: [
+              anyOf: [
                 {
                   $ref: '#/components/schemas/Empty',
                 },
                 {
-                  type: ['object', 'null'],
-                  deprecated: true,
+                  type: 'null',
                 },
               ],
+              deprecated: true,
             },
           },
         },

--- a/spec/types/json.spec.ts
+++ b/spec/types/json.spec.ts
@@ -55,7 +55,7 @@ describe('json', () => {
             {
               type: 'array',
               items: {
-                oneOf: [
+                anyOf: [
                   { $ref: '#/components/schemas/Json' },
                   { type: 'null' },
                 ],
@@ -64,7 +64,7 @@ describe('json', () => {
             {
               type: 'object',
               additionalProperties: {
-                oneOf: [
+                anyOf: [
                   { $ref: '#/components/schemas/Json' },
                   { type: 'null' },
                 ],

--- a/spec/types/recursive-schemas.spec.ts
+++ b/spec/types/recursive-schemas.spec.ts
@@ -472,7 +472,7 @@ describe('recursive schemas (new getter approach)', () => {
             properties: {
               value: { type: 'string' },
               child: {
-                oneOf: [
+                anyOf: [
                   { $ref: '#/components/schemas/RecursiveNullable' },
                   { type: 'null' },
                 ],

--- a/src/openapi-generator.ts
+++ b/src/openapi-generator.ts
@@ -73,7 +73,7 @@ export interface OpenApiVersionSpecifics {
   ):
     | ReferenceObject
     | { allOf: (ReferenceObject | { nullable: boolean })[] }
-    | { oneOf: (ReferenceObject | { type: 'null' })[] };
+    | { anyOf: (ReferenceObject | { type: 'null' })[] };
 
   mapTupleItems(schemas: (SchemaObject | ReferenceObject)[]): {
     items?: SchemaObject | ReferenceObject;
@@ -531,12 +531,13 @@ export class OpenAPIGenerator {
     const referenceObject: ReferenceObject = {
       $ref: this.generateSchemaRef(refId),
     };
+    const isNullable = isNullableSchema(zodSchema);
 
     // We are currently calculating this schema or there is nothing
     if (this.schemaRefs[refId] === 'pending') {
       return this.versionSpecifics.mapNullableOfRef(
         referenceObject,
-        isNullableSchema(zodSchema)
+        isNullable
       );
     }
 
@@ -552,6 +553,19 @@ export class OpenAPIGenerator {
       return {
         allOf: [referenceObject, newMetadata],
       };
+    }
+
+    const nullableReferenceObject = this.versionSpecifics.mapNullableOfRef(
+      referenceObject,
+      isNullable
+    );
+
+    if (
+      isNullable &&
+      !('allOf' in nullableReferenceObject) &&
+      !this.schemaRefAlreadyAcceptsNull(schemaRef)
+    ) {
+      return Metadata.applySchemaMetadata(nullableReferenceObject, newMetadata);
     }
 
     // New metadata from zodSchema properties.
@@ -572,6 +586,20 @@ export class OpenAPIGenerator {
     }
 
     return referenceObject;
+  }
+
+  private schemaRefAlreadyAcceptsNull(
+    schemaRef: SchemaObject | ReferenceObject
+  ) {
+    if ('$ref' in schemaRef) {
+      return false;
+    }
+
+    if (schemaRef.nullable) {
+      return true;
+    }
+
+    return Array.isArray(schemaRef.type) && schemaRef.type.includes('null');
   }
 
   /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -55,7 +55,7 @@ export type MapNullableRef = (
   ref: ReferenceObject
 ) =>
   | ReferenceObject
-  | { oneOf: (ReferenceObject | { type: 'null' })[] }
+  | { anyOf: (ReferenceObject | { type: 'null' })[] }
   | { allOf: (ReferenceObject | { nullable: boolean })[] };
 
 export type MapNullableTypeWithNullable = (

--- a/src/v3.1/specifics.ts
+++ b/src/v3.1/specifics.ts
@@ -52,10 +52,10 @@ export class OpenApiGeneratorV31Specifics implements OpenApiVersionSpecifics {
   mapNullableOfRef(
     ref: ReferenceObject,
     isNullable: boolean
-  ): ReferenceObject | { oneOf: (ReferenceObject | { type: 'null' })[] } {
+  ): ReferenceObject | { anyOf: (ReferenceObject | { type: 'null' })[] } {
     if (isNullable) {
       return {
-        oneOf: [ref, this.nullType],
+        anyOf: [ref, this.nullType],
       };
     }
     return ref;


### PR DESCRIPTION
OpenAPI 3.1 nullable referenced schemas were emitted through allOf with a nullable type override. That is not equivalent to `$ref | null`, because null still has to satisfy the referenced schema branch.

Emit nullable refs as `anyOf: [$ref, { type: "null" }]` for OpenAPI 3.1 so `.nullable()` matches an explicit `z.union([schema, z.null()])`.

Preserve OpenAPI 3.0 nullable ref behavior and add regression coverage for registered object schemas used through refs.